### PR TITLE
fix: disconnect connected buses at end of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Dependencies
         run: poetry install
       - name: Test with Pytest
-        run: export $(dbus-launch); poetry run pytest --cov-report=xml -vvv
+        run: export $(dbus-launch); poetry run pytest --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Dependencies
         run: poetry install
       - name: Test with Pytest
-        run: export $(dbus-launch); poetry run pytest --cov-report=xml
+        run: export $(dbus-launch); poetry run pytest --cov-report=xml -vvv
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -140,3 +140,4 @@ def test_glib_properties():
             raise e
 
     service_bus.disconnect()
+    bus.disconnect()

--- a/tests/service/test_export.py
+++ b/tests/service/test_export.py
@@ -65,6 +65,8 @@ async def test_export_unexport():
     assert not node.interfaces
     assert not node.nodes
 
+    bus.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_export_alias():
@@ -102,6 +104,8 @@ async def test_export_alias():
     assert result.message_type is MessageType.METHOD_RETURN, result.body[0]
     assert interface._method_called
 
+    bus.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_export_introspection():
@@ -117,3 +121,5 @@ async def test_export_introspection():
 
     root = bus._introspect_export_path("/")
     assert len(root.nodes) == 1
+
+    bus.disconnect()

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -179,3 +179,6 @@ async def test_methods(interface_class):
 
     reply = await call("throws_dbus_error", flags=MessageFlag.NO_REPLY_EXPECTED)
     assert reply is None
+
+    bus1.disconnect()
+    bus2.disconnect()

--- a/tests/service/test_properties.py
+++ b/tests/service/test_properties.py
@@ -243,6 +243,9 @@ async def test_property_methods(interface_class):
     assert result.error_name == "test.error"
     assert result.body == ["told you so"]
 
+    bus1.disconnect()
+    bus2.disconnect()
+
 
 @pytest.mark.parametrize("interface_class", [ExampleInterface, AsyncInterface])
 @pytest.mark.asyncio
@@ -295,3 +298,6 @@ async def test_property_changed_signal(interface_class):
         {"string_prop": Variant("s", "asdf")},
         ["container_prop"],
     ]
+
+    bus1.disconnect()
+    bus2.disconnect()

--- a/tests/service/test_signals.py
+++ b/tests/service/test_signals.py
@@ -159,6 +159,9 @@ async def test_signals():
     with pytest.raises(SignalDisabledError):
         interface.signal_disabled()
 
+    bus1.disconnect()
+    bus2.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_interface_add_remove_signal():
@@ -249,3 +252,6 @@ async def test_interface_add_remove_signal():
             signature="oas",
             body=[export_path, ["test.interface.first", "test.interface.second"]],
         )
+
+    bus1.disconnect()
+    bus2.disconnect()

--- a/tests/service/test_standard_interfaces.py
+++ b/tests/service/test_standard_interfaces.py
@@ -79,6 +79,9 @@ async def test_introspectable_interface():
     assert not node.interfaces
     assert not node.nodes
 
+    bus1.disconnect()
+    bus2.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_peer_interface():
@@ -109,6 +112,9 @@ async def test_peer_interface():
 
     assert reply.message_type == MessageType.METHOD_RETURN, reply.body[0]
     assert reply.signature == "s"
+
+    bus1.disconnect()
+    bus2.disconnect()
 
 
 @pytest.mark.asyncio
@@ -180,6 +186,9 @@ async def test_object_manager():
     expected_reply.update(reply_ext)
     assert reply_root.body == [expected_reply]
 
+    bus1.disconnect()
+    bus2.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_standard_interface_properties():
@@ -236,3 +245,6 @@ async def test_standard_interface_properties():
         )
         assert result.message_type is MessageType.METHOD_RETURN
         assert result.body == [{}]
+
+    bus1.disconnect()
+    bus2.disconnect()

--- a/tests/test_aio_low_level.py
+++ b/tests/test_aio_low_level.py
@@ -41,6 +41,8 @@ async def test_standard_interfaces():
     assert reply.signature == "s"
     assert type(reply.body[0]) is str
 
+    bus.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_sending_messages_between_buses():
@@ -103,6 +105,9 @@ async def test_sending_messages_between_buses():
     reply = await bus2.call(msg)
     assert reply is None
 
+    bus1.disconnect()
+    bus2.disconnect()
+
 
 @pytest.mark.asyncio
 async def test_sending_signals_between_buses(event_loop):
@@ -145,3 +150,6 @@ async def test_sending_signals_between_buses(event_loop):
     assert signal.member == "SomeSignal"
     assert signal.signature == "s"
     assert signal.body == ["a signal"]
+
+    bus1.disconnect()
+    bus2.disconnect()

--- a/tests/test_big_message.py
+++ b/tests/test_big_message.py
@@ -39,6 +39,9 @@ async def test_aio_big_message():
     assert result.message_type == MessageType.METHOD_RETURN, result.body[0]
     assert result.body[0] == big_body[0]
 
+    bus1.disconnect()
+    bus2.disconnect()
+
 
 @pytest.mark.skipif(not has_gi, reason=skip_reason_no_gi)
 def test_glib_big_message():
@@ -62,3 +65,6 @@ def test_glib_big_message():
     )
     assert result.message_type == MessageType.METHOD_RETURN, result.body[0]
     assert result.body[0] == big_body[0]
+
+    bus1.disconnect()
+    bus2.disconnect()

--- a/tests/test_fd_passing.py
+++ b/tests/test_fd_passing.py
@@ -278,6 +278,8 @@ async def test_sending_file_descriptor_with_proxy(event_loop):
     interface.cleanup()
     os.close(fd)
 
+    bus.disconnect()
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/tests/test_glib_low_level.py
+++ b/tests/test_glib_low_level.py
@@ -47,6 +47,8 @@ def test_standard_interfaces():
     assert reply.signature == "s"
     assert type(reply.body[0]) is str
 
+    bus.disconnect()
+
 
 @pytest.mark.skipif(not has_gi, reason=skip_reason_no_gi)
 def test_sending_messages_between_buses():
@@ -109,6 +111,9 @@ def test_sending_messages_between_buses():
     reply = bus2.call_sync(msg)
     assert reply is None
 
+    bus1.disconnect()
+    bus2.disconnect()
+
 
 @pytest.mark.skipif(not has_gi, reason=skip_reason_no_gi)
 def test_sending_signals_between_buses():
@@ -156,3 +161,6 @@ def test_sending_signals_between_buses():
     assert signal.member == "SomeSignal"
     assert signal.signature == "s"
     assert signal.body == ["a signal"]
+
+    bus1.disconnect()
+    bus2.disconnect()


### PR DESCRIPTION
Last build failed for confusing reasons. I suspect from the error the real reason is something not being released between tests. Adding a call to `bus.disconnect` at the end of every test which connects to the bus seems to fix it.