### PR TITLE
feat: improve asyncio write performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Dependencies
         run: poetry install
       - name: Test with Pytest
-        run: export $(dbus-launch); poetry run pytest -vvvs --cov-report=xml
+        run: export $(dbus-launch); poetry run pytest --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Dependencies
         run: poetry install
       - name: Test with Pytest
-        run: export $(dbus-launch); poetry run pytest --cov-report=xml
+        run: export $(dbus-launch); poetry run pytest -vvvs --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -107,9 +107,7 @@ class _MessageWriter:
         # Optimization: try to send now.
         if queue_is_empty:
             self.write_callback(remove_writer=False)
-        # don't run the writer until the bus is ready to send messages
-        if self.buf is not None or self.messages.qsize() != 0:
-            self.loop.add_writer(self.fd, self.write_callback)
+        self.loop.add_writer(self.fd, self.write_callback)
 
 
 class MessageBus(BaseMessageBus):

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -53,7 +53,8 @@ class _MessageWriter:
                 if self.buf is None:
                     if self.messages.qsize() == 0:
                         # nothing more to write
-                        self.loop.remove_writer(self.fd)
+                        if remove_writer:
+                            self.loop.remove_writer(self.fd)
                         return
                     buf, unix_fds, fut = self.messages.get_nowait()
                     self.unix_fds = unix_fds

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -113,7 +113,12 @@ class _MessageWriter:
             # is a huge improvement in latency.
             if queue_is_empty:
                 self._write_without_remove_writer()
-            if self.messages.qsize() != 0 or not self.fut or not self.fut.done():
+            if (
+                self.buf is not None
+                or self.messages.qsize() != 0
+                or not self.fut
+                or not self.fut.done()
+            ):
                 self.loop.add_writer(self.fd, self.write_callback)
 
 

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -106,12 +106,14 @@ class _MessageWriter:
         queue_is_empty = self.messages.qsize() == 0
         if msg is not None:
             self.buffer_message(msg, future)
-        if not self.bus.unique_name:
-            return
-        # Optimization: try to send now.
-        if queue_is_empty:
-            self._write_without_remove_writer()
-        self.loop.add_writer(self.fd, self.write_callback)
+        if self.bus.unique_name:
+            # Optimization: try to send now if the queue
+            # is empty. With bleak this usually means we
+            # can send right away 85% of the time which
+            # is a huge improvement in latency.
+            if queue_is_empty:
+                self._write_without_remove_writer()
+            self.loop.add_writer(self.fd, self.write_callback)
 
 
 class MessageBus(BaseMessageBus):

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -107,7 +107,7 @@ class _MessageWriter:
             if queue_is_empty:
                 self.write_callback(remove_writer=False)
             # don't run the writer until the bus is ready to send messages
-            if self.messages.qsize() != 0:
+            if self.buf is not None or self.messages.qsize() != 0:
                 self.loop.add_writer(self.fd, self.write_callback)
 
 

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -98,11 +98,13 @@ class _MessageWriter:
         )
 
     def schedule_write(self, msg: Message = None, future=None):
+        queue_is_empty = self.messages.qsize() == 0
         if msg is not None:
             self.buffer_message(msg, future)
         if self.bus.unique_name:
             # Optimization: try to send now.
-            self.write_callback()
+            if queue_is_empty:
+                self.write_callback()
             # don't run the writer until the bus is ready to send messages
             if self.messages.qsize() != 0:
                 self.loop.add_writer(self.fd, self.write_callback)

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -98,6 +98,10 @@ class _MessageWriter:
             )
         )
 
+    def _write_without_remove_writer(self):
+        """Call the write callback without removing the writer."""
+        self.write_callback(remove_writer=False)
+
     def schedule_write(self, msg: Message = None, future=None):
         queue_is_empty = self.messages.qsize() == 0
         if msg is not None:
@@ -106,7 +110,7 @@ class _MessageWriter:
             return
         # Optimization: try to send now.
         if queue_is_empty:
-            self.write_callback(remove_writer=False)
+            self._write_without_remove_writer()
         self.loop.add_writer(self.fd, self.write_callback)
 
 

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -102,13 +102,14 @@ class _MessageWriter:
         queue_is_empty = self.messages.qsize() == 0
         if msg is not None:
             self.buffer_message(msg, future)
-        if self.bus.unique_name:
-            # Optimization: try to send now.
-            if queue_is_empty:
-                self.write_callback(remove_writer=False)
-            # don't run the writer until the bus is ready to send messages
-            if self.buf is not None or self.messages.qsize() != 0:
-                self.loop.add_writer(self.fd, self.write_callback)
+        if not self.bus.unique_name:
+            return
+        # Optimization: try to send now.
+        if queue_is_empty:
+            self.write_callback(remove_writer=False)
+        # don't run the writer until the bus is ready to send messages
+        if self.buf is not None or self.messages.qsize() != 0:
+            self.loop.add_writer(self.fd, self.write_callback)
 
 
 class MessageBus(BaseMessageBus):

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -113,7 +113,7 @@ class _MessageWriter:
             # is a huge improvement in latency.
             if queue_is_empty:
                 self._write_without_remove_writer()
-            if not self.fut or not self.fut.done():
+            if self.messages.qsize() != 0 or not self.fut or not self.fut.done():
                 self.loop.add_writer(self.fd, self.write_callback)
 
 

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -45,7 +45,7 @@ class _MessageWriter:
         self.fd = bus._fd
         self.offset = 0
         self.unix_fds = None
-        self.fut = None
+        self.fut: Optional[asyncio.Future] = None
 
     def write_callback(self, remove_writer: bool = True) -> None:
         try:
@@ -113,7 +113,8 @@ class _MessageWriter:
             # is a huge improvement in latency.
             if queue_is_empty:
                 self._write_without_remove_writer()
-            self.loop.add_writer(self.fd, self.write_callback)
+            if not self.fut or not self.fut.done():
+                self.loop.add_writer(self.fd, self.write_callback)
 
 
 class MessageBus(BaseMessageBus):

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -47,7 +47,7 @@ class _MessageWriter:
         self.unix_fds = None
         self.fut = None
 
-    def write_callback(self):
+    def write_callback(self, remove_writer: bool = True) -> None:
         try:
             while True:
                 if self.buf is None:
@@ -104,7 +104,7 @@ class _MessageWriter:
         if self.bus.unique_name:
             # Optimization: try to send now.
             if queue_is_empty:
-                self.write_callback()
+                self.write_callback(remove_writer=False)
             # don't run the writer until the bus is ready to send messages
             if self.messages.qsize() != 0:
                 self.loop.add_writer(self.fd, self.write_callback)

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -109,7 +109,7 @@ class _MessageWriter:
         if self.bus.unique_name:
             # Optimization: try to send now if the queue
             # is empty. With bleak this usually means we
-            # can send right away 85% of the time which
+            # can send right away 99% of the time which
             # is a huge improvement in latency.
             if queue_is_empty:
                 self._write_without_remove_writer()

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -101,8 +101,11 @@ class _MessageWriter:
         if msg is not None:
             self.buffer_message(msg, future)
         if self.bus.unique_name:
+            # Optimization: try to send now.
+            self.write_callback()
             # don't run the writer until the bus is ready to send messages
-            self.loop.add_writer(self.fd, self.write_callback)
+            if self.messages.qsize() != 0:
+                self.loop.add_writer(self.fd, self.write_callback)
 
 
 class MessageBus(BaseMessageBus):

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -17,7 +17,7 @@ async def test_bus_disconnect_before_reply(event_loop):
     await bus.connect()
     assert bus.connected
 
-    with patch.object(bus, "write_callback"):
+    with patch.object(bus, "_write_without_remove_writer"):
         ping = bus.call(
             Message(
                 destination="org.freedesktop.DBus",
@@ -27,10 +27,10 @@ async def test_bus_disconnect_before_reply(event_loop):
             )
         )
 
-    event_loop.call_soon(bus.disconnect)
+        event_loop.call_soon(bus.disconnect)
 
-    with pytest.raises((EOFError, BrokenPipeError)):
-        await ping
+        with pytest.raises((EOFError, BrokenPipeError)):
+            await ping
 
     assert bus._disconnected
     assert not bus.connected

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -1,5 +1,6 @@
 import functools
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -16,14 +17,15 @@ async def test_bus_disconnect_before_reply(event_loop):
     await bus.connect()
     assert bus.connected
 
-    ping = bus.call(
-        Message(
-            destination="org.freedesktop.DBus",
-            path="/org/freedesktop/DBus",
-            interface="org.freedesktop.DBus",
-            member="Ping",
+    with patch.object(bus, "write_callback"):
+        ping = bus.call(
+            Message(
+                destination="org.freedesktop.DBus",
+                path="/org/freedesktop/DBus",
+                interface="org.freedesktop.DBus",
+                member="Ping",
+            )
         )
-    )
 
     event_loop.call_soon(bus.disconnect)
 

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -17,7 +17,7 @@ async def test_bus_disconnect_before_reply(event_loop):
     await bus.connect()
     assert bus.connected
 
-    with patch.object(bus, "_write_without_remove_writer"):
+    with patch.object(bus._writer, "_write_without_remove_writer"):
         ping = bus.call(
             Message(
                 destination="org.freedesktop.DBus",

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -62,5 +62,5 @@ async def test_unexpected_disconnect(event_loop):
         assert bus._disconnected
         assert not bus.connected
 
-        with pytest.raises(OSError):
-            await bus.wait_for_disconnect()
+    with pytest.raises(OSError):
+        await bus.wait_for_disconnect()


### PR DESCRIPTION
Similar to https://github.com/python/cpython/blob/2a50772b63d7bc4ef97d16e9bcc53455c301b0ea/Lib/asyncio/selector_events.py?rgh-link-date=2022-09-24T02%3A51%3A37Z#L914

With this change ~99% of writes don't need to be scheduled and can happen right away so it helps quite a bit with the latency

I was able to get sub 1s connection times on my yale locks with this change
```
2022-09-23 21:25:16.427 DEBUG (MainThread) [bleak_retry_connector] Family Room Door (M1028EZ) - /org/bluez/hci3/dev_78_9C_85_08_D2_CE: Connecting (attempt: 1, last rssi: -76)
2022-09-23 21:25:16.727 DEBUG (MainThread) [bleak_retry_connector] Family Room Door (M1028EZ) - /org/bluez/hci3/dev_78_9C_85_08_D2_CE: Connected (attempt: 1, last rssi: -76)
```

Previously the best I could do was slightly > 1s

fixes #28