### PR TITLE
feat: use async_timeout instead of asyncio.wait_for

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "async-timeout"
+version = "4.0.2"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.5", markers = "python_version < \"3.8\""}
+
+[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -580,12 +591,16 @@ docs = ["myst-parser", "Sphinx", "sphinx-rtd-theme", "sphinxcontrib-asyncio", "s
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "b5789469d95eaf4e986d80cb2ced01a23947e039ac09412324289fa59d3ccb57"
+content-hash = "8ae29d14a672b75b019751b86f62cc0c4be6c72e08f25c4c24df7ec18fb232ab"
 
 [metadata.files]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+async-timeout = [
+    {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
+    {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
 ]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ sphinxcontrib-fulltoc = {version = "^1.2.0", extras = ["docs"]}
 Sphinx = {version = "^5.1.1", extras = ["docs"]}
 myst-parser = {version = "^0.18.0", extras = ["docs"]}
 sphinx-rtd-theme = {version = "^1.0.0", extras = ["docs"]}
+async-timeout = ">=4.0.1"
 
 [tool.poetry.extras]
 docs = [

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -6,6 +6,8 @@ from collections import deque
 from copy import copy
 from typing import Any, Optional
 
+import async_timeout
+
 from .. import introspection as intr
 from .._private.unmarshaller import Unmarshaller
 from ..auth import Authenticator, AuthExternal
@@ -257,7 +259,8 @@ class MessageBus(BaseMessageBus):
 
         super().introspect(bus_name, path, reply_handler)
 
-        return await asyncio.wait_for(future, timeout=timeout)
+        async with async_timeout.timeout(timeout):
+            return await future
 
     async def request_name(
         self, name: str, flags: NameFlag = NameFlag.NONE


### PR DESCRIPTION
Avoids creating a task which will make it easier
to trace down races in the aio message_bus write_callback

We currently have a race (maybe destruction race) in
https://github.com/Bluetooth-Devices/dbus-fast/blob/d71f0e1fbd7282cbd78402414158545ba7176f6e/src/dbus_fast/aio/message_bus.py#L78

where somehow `self.buf` is `None`