### PR TITLE
fix: loosen async-timeout pin to 3.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -591,7 +591,7 @@ docs = ["myst-parser", "Sphinx", "sphinx-rtd-theme", "sphinxcontrib-asyncio", "s
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "8ae29d14a672b75b019751b86f62cc0c4be6c72e08f25c4c24df7ec18fb232ab"
+content-hash = "9fd2eabd8a7994fff6fe3158104f040dee41b33c9ab2ce7e563f40f20b0d643b"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ sphinxcontrib-fulltoc = {version = "^1.2.0", extras = ["docs"]}
 Sphinx = {version = "^5.1.1", extras = ["docs"]}
 myst-parser = {version = "^0.18.0", extras = ["docs"]}
 sphinx-rtd-theme = {version = "^1.0.0", extras = ["docs"]}
-async-timeout = ">=4.0.1"
+async-timeout = ">=3.0.0"
 
 [tool.poetry.extras]
 docs = [


### PR DESCRIPTION
https://github.com/Bluetooth-Devices/dbus-fast/pull/38#discussion_r980363091