### PR TITLE
feat: speed up message bus matching

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -773,11 +773,11 @@ class BaseMessageBus:
                     break
 
         if msg.message_type == MessageType.SIGNAL:
-            if msg._matches(
-                member="NameOwnerChanged",  # least likely to match
-                sender="org.freedesktop.DBus",
-                path="/org/freedesktop/DBus",
-                interface="org.freedesktop.DBus",
+            if (
+                msg.member == "NameOwnerChanged"
+                and msg.sender == "org.freedesktop.DBus"
+                and msg.path == "/org/freedesktop/DBus"
+                and msg.interface == "org.freedesktop.DBus"
             ):
                 [name, old_owner, new_owner] = msg.body
                 if new_owner:
@@ -827,23 +827,24 @@ class BaseMessageBus:
     ) -> Optional[Callable[[Message, Callable], None]]:
         handler = None
 
-        if msg._matches(
-            interface="org.freedesktop.DBus.Introspectable",
-            member="Introspect",
-            signature="",
+        if (
+            msg.interface == "org.freedesktop.DBus.Introspectable"
+            and msg.member == "Introspect"
+            and msg.signature == ""
         ):
             handler = self._default_introspect_handler
 
-        elif msg._matches(interface="org.freedesktop.DBus.Properties"):
+        elif msg.interface == "org.freedesktop.DBus.Properties":
             handler = self._default_properties_handler
 
-        elif msg._matches(interface="org.freedesktop.DBus.Peer"):
-            if msg._matches(member="Ping", signature=""):
+        elif msg.interface == "org.freedesktop.DBus.Peer":
+            if msg.member == "Ping" and msg.signature == "":
                 handler = self._default_ping_handler
-            elif msg._matches(member="GetMachineId", signature=""):
+            elif msg.member == "GetMachineId" and msg.signature == "":
                 handler = self._default_get_machine_id_handler
-        elif msg._matches(
-            interface="org.freedesktop.DBus.ObjectManager", member="GetManagedObjects"
+        elif (
+            msg.interface == "org.freedesktop.DBus.ObjectManager"
+            and msg.member == "GetManagedObjects"
         ):
             handler = self._default_get_managed_objects_handler
 
@@ -852,10 +853,10 @@ class BaseMessageBus:
                 for method in ServiceInterface._get_methods(interface):
                     if method.disabled:
                         continue
-                    if msg._matches(
-                        interface=interface.name,
-                        member=method.name,
-                        signature=method.in_signature,
+                    if (
+                        msg.interface == interface.name
+                        and msg.member == method.name
+                        and msg.signature == method.in_signature
                     ):
                         handler = self._make_method_handler(interface, method)
                         break

--- a/src/dbus_fast/proxy_object.py
+++ b/src/dbus_fast/proxy_object.py
@@ -98,11 +98,9 @@ class BaseProxyInterface:
 
     def _message_handler(self, msg: Message) -> None:
         if (
-            not msg._matches(
-                message_type=MessageType.SIGNAL,
-                interface=self.introspection.name,
-                path=self.path,
-            )
+            msg.message_type != MessageType.SIGNAL
+            or msg.interface != self.introspection.name
+            or msg.path != self.path
             or msg.member not in self._signal_handlers
         ):
             return


### PR DESCRIPTION
remove slower _matches calls

These calls were re-implementing `if` statements under the hood.  Write them out instead as it much faster and we don't lose out on typing.