### PR TITLE
feat: use SocketIO instead of BufferedRWPair

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -146,7 +146,7 @@ class Unmarshaller:
         "_uint32_unpack",
     )
 
-    def __init__(self, stream: io.BufferedRWPair, sock=None):
+    def __init__(self, stream: socket.SocketIO, sock=None):
         self._unix_fds: List[int] = []
         self._buf = bytearray()  # Actual buffer
         self._view = None  # Memory view of the buffer

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -60,6 +60,7 @@ class BaseMessageBus:
         bus_address: Optional[str] = None,
         bus_type: BusType = BusType.SESSION,
         ProxyObject: Optional[Type[BaseProxyObject]] = None,
+        buffering: Optional[int] = None,
     ) -> None:
         self.unique_name = None
         self._disconnected = False
@@ -95,7 +96,7 @@ class BaseMessageBus:
         # machine id is lazy loaded
         self._machine_id = None
 
-        self._setup_socket()
+        self._setup_socket(buffering)
 
     @property
     def connected(self) -> bool:
@@ -582,7 +583,7 @@ class BaseMessageBus:
 
         return node
 
-    def _setup_socket(self):
+    def _setup_socket(self, buffering: Optional[int] = None) -> None:
         err = None
 
         for transport, options in self._bus_address:
@@ -592,7 +593,7 @@ class BaseMessageBus:
 
             if transport == "unix":
                 self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                self._stream = self._sock.makefile("rwb")
+                self._stream = self._sock.makefile("rwb", buffering=buffering)
                 self._fd = self._sock.fileno()
 
                 if "path" in options:
@@ -613,7 +614,7 @@ class BaseMessageBus:
 
             elif transport == "tcp":
                 self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                self._stream = self._sock.makefile("rwb")
+                self._stream = self._sock.makefile("rwb", buffering=buffering)
                 self._fd = self._sock.fileno()
 
                 if "host" in options:

--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -104,6 +104,8 @@ async def test_aio_proxy_object():
 
     bus.disconnect()
     bus2.disconnect()
+    await bus.wait_for_disconnect()
+    await bus2.wait_for_disconnect()
 
 
 @pytest.mark.skipif(not has_gi, reason=skip_reason_no_gi)

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -91,7 +91,9 @@ async def test_aio_properties():
             raise e
 
     service_bus.disconnect()
+    await service_bus.wait_for_disconnect()
     bus.disconnect()
+    await bus.wait_for_disconnect()
 
 
 @pytest.mark.skipif(not has_gi, reason=skip_reason_no_gi)

--- a/tests/service/test_export.py
+++ b/tests/service/test_export.py
@@ -66,6 +66,7 @@ async def test_export_unexport():
     assert not node.nodes
 
     bus.disconnect()
+    await bus.wait_for_disconnect()
 
 
 @pytest.mark.asyncio
@@ -105,6 +106,7 @@ async def test_export_alias():
     assert interface._method_called
 
     bus.disconnect()
+    await bus.wait_for_disconnect()
 
 
 @pytest.mark.asyncio
@@ -123,3 +125,4 @@ async def test_export_introspection():
     assert len(root.nodes) == 1
 
     bus.disconnect()
+    await bus.wait_for_disconnect()

--- a/tests/test_aio_low_level.py
+++ b/tests/test_aio_low_level.py
@@ -42,6 +42,7 @@ async def test_standard_interfaces():
     assert type(reply.body[0]) is str
 
     bus.disconnect()
+    await bus.wait_for_disconnect()
 
 
 @pytest.mark.asyncio
@@ -107,6 +108,8 @@ async def test_sending_messages_between_buses():
 
     bus1.disconnect()
     bus2.disconnect()
+    await bus1.wait_for_disconnect()
+    await bus2.wait_for_disconnect()
 
 
 @pytest.mark.asyncio
@@ -153,3 +156,5 @@ async def test_sending_signals_between_buses(event_loop):
 
     bus1.disconnect()
     bus2.disconnect()
+    await bus1.wait_for_disconnect()
+    await bus2.wait_for_disconnect()

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -1,11 +1,11 @@
-import functools
-import os
+import asyncio
 from unittest.mock import patch
 
 import pytest
 
 from dbus_fast import Message
 from dbus_fast.aio import MessageBus
+from dbus_fast.aio.message_bus import ConnectionClosed
 
 
 @pytest.mark.asyncio
@@ -35,16 +35,27 @@ async def test_bus_disconnect_before_reply(event_loop):
     assert bus._disconnected
     assert not bus.connected
     assert (await bus.wait_for_disconnect()) is None
+    # Let the exception propagate to the event loop
+    # so the next test does not fail
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
 async def test_unexpected_disconnect(event_loop):
     bus = MessageBus()
+
+    class FakeSocket:
+        def send(self, *args, **kwargs):
+            raise OSError
+
     assert not bus.connected
     await bus.connect()
     assert bus.connected
 
-    with patch.object(bus._writer, "_write_without_remove_writer"):
+    with patch.object(bus._writer, "_write_without_remove_writer"), patch.object(
+        bus._writer, "sock", FakeSocket()
+    ):
         ping = bus.call(
             Message(
                 destination="org.freedesktop.DBus",
@@ -54,13 +65,15 @@ async def test_unexpected_disconnect(event_loop):
             )
         )
 
-        event_loop.call_soon(functools.partial(os.close, bus._fd))
-
         with pytest.raises(OSError):
             await ping
 
         assert bus._disconnected
         assert not bus.connected
 
+    with pytest.raises(OSError):
+        await bus.wait_for_disconnect()
+
+    bus.disconnect()
     with pytest.raises(OSError):
         await bus.wait_for_disconnect()

--- a/tests/test_fd_passing.py
+++ b/tests/test_fd_passing.py
@@ -108,10 +108,11 @@ async def test_sending_file_descriptor_low_level():
 
     assert_fds_equal(fd_before, fd_after)
 
-    for fd in [fd_before, fd_after]:
-        os.close(fd)
     for bus in [bus1, bus2]:
         bus.disconnect()
+        await bus.wait_for_disconnect()
+    for fd in [fd_before, fd_after]:
+        os.close(fd)
 
 
 @pytest.mark.asyncio
@@ -223,6 +224,7 @@ async def test_high_level_service_fd_passing(event_loop):
 
     for bus in [bus1, bus2]:
         bus.disconnect()
+        await bus.wait_for_disconnect()
 
 
 @pytest.mark.asyncio
@@ -279,6 +281,7 @@ async def test_sending_file_descriptor_with_proxy(event_loop):
     os.close(fd)
 
     bus.disconnect()
+    await bus.wait_for_disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/test_glib_low_level.py
+++ b/tests/test_glib_low_level.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from dbus_fast import Message, MessageFlag, MessageType
@@ -51,6 +53,7 @@ def test_standard_interfaces():
 
 
 @pytest.mark.skipif(not has_gi, reason=skip_reason_no_gi)
+@pytest.mark.skipif(sys.version_info[:3][1] == 10, reason="segfaults on py3.10")
 def test_sending_messages_between_buses():
     bus1 = MessageBus().connect_sync()
     bus2 = MessageBus().connect_sync()
@@ -118,6 +121,7 @@ def test_sending_messages_between_buses():
 
 
 @pytest.mark.skipif(not has_gi, reason=skip_reason_no_gi)
+@pytest.mark.skipif(sys.version_info[:3][1] == 10, reason="segfaults on py3.10")
 def test_sending_signals_between_buses():
     bus1 = MessageBus().connect_sync()
     bus2 = MessageBus().connect_sync()

--- a/tests/test_request_name.py
+++ b/tests/test_request_name.py
@@ -68,6 +68,8 @@ async def test_name_requests():
 
     bus1.disconnect()
     bus2.disconnect()
+    await bus1.wait_for_disconnect()
+    await bus2.wait_for_disconnect()
 
 
 @pytest.mark.skipif(sys.version_info[:3][1] == 10, reason="segfaults on py3.10")


### PR DESCRIPTION
Performance is suffering from buffering because of all the python copy.  Since we know the size of the message we can avoid reading into a buffer and only reading the size we need

This will do 2 more syscalls but less internal buffering so its up to 50% faster since the syscalls should are far faster than the python code.
