### PR TITLE
fix: disconnect race in tests

### DIFF
--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -1,5 +1,4 @@
-import functools
-import os
+import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -35,16 +34,27 @@ async def test_bus_disconnect_before_reply(event_loop):
     assert bus._disconnected
     assert not bus.connected
     assert (await bus.wait_for_disconnect()) is None
+    # Let the exception propagate to the event loop
+    # so the next test does not fail
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
 async def test_unexpected_disconnect(event_loop):
     bus = MessageBus()
+
+    class FakeSocket:
+        def send(self, *args, **kwargs):
+            raise OSError
+
     assert not bus.connected
     await bus.connect()
     assert bus.connected
 
-    with patch.object(bus._writer, "_write_without_remove_writer"):
+    with patch.object(bus._writer, "_write_without_remove_writer"), patch.object(
+        bus._writer, "sock", FakeSocket()
+    ):
         ping = bus.call(
             Message(
                 destination="org.freedesktop.DBus",
@@ -54,13 +64,15 @@ async def test_unexpected_disconnect(event_loop):
             )
         )
 
-        event_loop.call_soon(functools.partial(os.close, bus._fd))
-
         with pytest.raises(OSError):
             await ping
 
         assert bus._disconnected
         assert not bus.connected
 
+    with pytest.raises(OSError):
+        await bus.wait_for_disconnect()
+
+    bus.disconnect()
     with pytest.raises(OSError):
         await bus.wait_for_disconnect()


### PR DESCRIPTION
Fixes the test closing out the underlying fd and getting python confused which lead to random failures and segfaults