### PR TITLE
feat: speed up unpack_variants

### DIFF
--- a/bench/unpack_variants.py
+++ b/bench/unpack_variants.py
@@ -2,6 +2,9 @@ import timeit
 
 from dbus_fast import Variant, unpack_variants
 
+# cythonize -X language_level=3 -a -i  src/dbus_fast/unpack.py
+
+
 message = {
     "/org/bluez/hci0": {
         "org.bluez.Adapter1": {

--- a/src/dbus_fast/unpack.py
+++ b/src/dbus_fast/unpack.py
@@ -4,15 +4,20 @@ from .signature import Variant
 
 
 def unpack_variants(data: Any) -> Any:
-    """Unpack variants and remove signature info."""
+    """Unpack variants and remove signature info.
+
+    This function should only be used to unpack
+    unmarshalled data as the checks are not
+    idiomatic.
+    """
     return _unpack_variants(data)
 
 
 def _unpack_variants(data: Any) -> Any:
-    if isinstance(data, dict):
+    if type(data) is dict:
         return {k: _unpack_variants(v) for k, v in data.items()}
-    if isinstance(data, list):
+    if type(data) is list:
         return [_unpack_variants(item) for item in data]
-    if isinstance(data, Variant):
+    if type(data) is Variant:
         return _unpack_variants(data.value)
     return data


### PR DESCRIPTION
This function needs to only unpack very specific types since the data is coming from the unmarshaller. The isinstance checks are not needed here and a type check is all that is needed.  This speeds up the run by 30%