### PR TITLE
fix: pass return value to SendReply.__exit__

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -762,8 +762,8 @@ class BaseMessageBus:
                 exc_type: Optional[Type[Exception]],
                 exc_value: Optional[Exception],
                 tb: Optional[TracebackType],
-            ) -> None:
-                self._exit(exc_type, exc_value, tb)
+            ) -> bool:
+                return self._exit(exc_type, exc_value, tb)
 
             def send_error(self, exc: Exception) -> None:
                 self._exit(exc.__class__, exc, exc.__traceback__)


### PR DESCRIPTION
To return an error in a ServiceInterface, you raise a DBusError which is caught and translated to a message and sent over the bus. However, the context manager that catches this exception was incorrectly not sending a return value of True when the exception was handled. This caused the _message_reader() returned by build_message_reader() to log the error even though it was handled.