### PR TITLE
feat: speed up marshall align

### DIFF
--- a/src/dbus_fast/_private/marshaller.py
+++ b/src/dbus_fast/_private/marshaller.py
@@ -29,7 +29,8 @@ class Marshaller:
         offset = n - len(self._buf) % n
         if offset == 0 or offset == n:
             return 0
-        self._buf.extend(bytes(offset))
+        for _ in range(offset):
+            self._buf.append(0)
         return offset
 
     def write_boolean(self, boolean: bool, type_: SignatureType) -> int:


### PR DESCRIPTION
This is a 5% speed up.

By writing this as a loop cython will write
__Pyx_PyByteArray_Append instead of a ~20
lines of python call stack

