### PR TITLE
chore: add coverage for non-cython big endian

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -141,6 +141,8 @@ try:
 except ImportError:
     from ._cython_compat import FAKE_CYTHON as cython
 
+IS_COMPILED = cython.compiled
+
 #
 # Alignment padding is handled with the following formula below
 #

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -105,8 +105,8 @@ def test_marshalling_with_table():
 def test_unmarshalling_with_table_endians(unmarshall_table, endians):
     from dbus_fast._private import unmarshaller
 
-    with patch.object(unmarshaller, "IS_BIG_ENDIAN", endians[0]), patch.object(
-        unmarshaller, "IS_LITTLE_ENDIAN", endians[1]
+    with patch.object(unmarshaller, "SYS_IS_BIG_ENDIAN", endians[0]), patch.object(
+        unmarshaller, "SYS_IS_LITTLE_ENDIAN", endians[1]
     ):
 
         for item in unmarshall_table:


### PR DESCRIPTION
Unfortunately I don't have an actual big endian system to test on so we can only add a patch