### PR TITLE
feat: reduce syscalls to unmarshall a message

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -269,14 +269,7 @@ class Unmarshaller:
         start_len = len(self._buf)
         missing_bytes = pos - (start_len - self._pos)
         if self._sock is None:
-            # It would be a bit more optimized if we could use
-            # getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF) instead
-            # of hardcoding the buffer size, but that would require
-            # more refactoring
-            if missing_bytes < 1024:
-                data = self._stream.read1(missing_bytes)
-            else:
-                data = self._stream.read(missing_bytes)
+            data = self._stream.read(missing_bytes)
         else:
             data = self._read_sock(missing_bytes)
         if data == b"":

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -269,7 +269,14 @@ class Unmarshaller:
         start_len = len(self._buf)
         missing_bytes = pos - (start_len - self._pos)
         if self._sock is None:
-            data = self._stream.read(missing_bytes)
+            # It would be a bit more optimized if we could use
+            # getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF) instead
+            # of hardcoding the buffer size, but that would require
+            # more refactoring
+            if missing_bytes < 1024:
+                data = self._stream.read1(missing_bytes)
+            else:
+                data = self._stream.read(missing_bytes)
         else:
             data = self._read_sock(missing_bytes)
         if data == b"":

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -31,6 +31,7 @@ def build_message_reader(
                         f"got unexpected error processing a message: {e}.\n{traceback.format_exc()}"
                     )
                 unmarshaller._reset()
+                return
         except Exception as e:
             finalize(e)
 


### PR DESCRIPTION
Before
```
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0'\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_60_55_F9_3C_34_DA\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\330\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 220
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0(\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_3D_68_55_07_BA_CB\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\303\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 220
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0)\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_56_CB_C1_D6_2E_EF\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\312\377\0\0\0\0\0\0l\4\1\0014\0\0\0*\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_28_2B_16_68_2C_E4\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\264\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 440
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0+\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_24_FC_E5_29_C2_E9\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\275\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 220
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0,\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_6B_2E_AF_66_84_ED\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\276\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 220
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0-\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_32_8C_83_EC_94_93\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\302\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 220
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0.\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_C1_C7_27_7D_55_AB\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\336\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 220
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0/\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_B4_E8_42_4A_73_8B\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\262\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 220
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
[pid    60] recvfrom(41, "l\4\1\0014\0\0\0000\337>\1\225\0\0\0\1\1o\0%\0\0\0/org/bluez/hci0/dev_60_55_F9_2B_36_C2\0\0\0\2\1s\0\37\0\0\0org.freedesktop.DBus.Properties\0\3\1s\0\21\0\0\0PropertiesChanged\0\0\0\0\0\0\0\10\1g\0\10sa{sv}as\0\0\0\7\1s\0\4\0\0\0:1.4\0\0\0\0\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\317\377\0\0\0\0\0\0", 8192, 0, NULL, NULL) = 220
[pid    60] recvfrom(41, 0xffff7fa6e000, 8192, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
```

After
```


```