### PR TITLE
fix: fix remaining altdesktop links

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ asyncio.run(main())
 
 ## Contributing
 
-Contributions are welcome. Development happens on [Github](https://github.com/altdesktop/python-dbus-fast).
+Contributions are welcome. Development happens on [Github](https://github.com/Bluetooth-Devices/dbus-fast).
 
 Before you commit, run `pre-commit run --all-files` to run the linter, code formatter, and the test suite.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,12 +55,12 @@ This library is available on PyPi as `dbus-fast <https://pypi.org/project/dbus-f
 Contributing
 ++++++++++++
 
-Development for this library happens on `Github <https://github.com/altdesktop/python-dbus-fast>`_. Report bugs or request features there. Contributions are welcome.
+Development for this library happens on `Github <https://github.com/Bluetooth-Devices/dbus-fast>`_. Report bugs or request features there. Contributions are welcome.
 
 License
 ++++++++
 
-This library is available under an `MIT License <https://github.com/altdesktop/python-dbus-fast/blob/master/LICENSE>`_.
+This library is available under an `MIT License <https://github.com/Bluetooth-Devices/dbus-fast/blob/main/LICENSE>`_.
 
 © 2022, Bluetooth Devices authors
 © 2019, Tony Crisci


### PR DESCRIPTION
There were still a few links incorrectly pointing back to altdesktop/python-dbus-next on GitHub.