### PR TITLE
feat: add return value to method decorator

### DIFF
--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -94,7 +94,7 @@ def method(name: str = None, disabled: bool = False):
     def decorator(fn):
         @wraps(fn)
         def wrapped(*args, **kwargs):
-            fn(*args, **kwargs)
+            return fn(*args, **kwargs)
 
         fn_name = name if name else fn.__name__
         wrapped.__dict__["__DBUS_METHOD"] = _Method(fn, fn_name, disabled=disabled)

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -52,7 +52,7 @@ class _Method:
         self.out_signature_tree = get_signature_tree(out_signature)
 
 
-def method(name: str = None, disabled: bool = False):
+def method(name: str = None, disabled: bool = False) -> Any:
     """A decorator to mark a class method of a :class:`ServiceInterface` to be a DBus service method.
 
     The parameters and return value must each be annotated with a signature
@@ -67,6 +67,10 @@ def method(name: str = None, disabled: bool = False):
 
     The decorated method may raise a :class:`DBusError <dbus_fast.DBusError>`
     to return an error to the client.
+
+    The decorator returns the return value of the decorated method; this allows
+    local calls to the decorated method to work as though the decorator were not
+    there.
 
     :param name: The member name that DBus clients will use to call this method. Defaults to the name of the class method.
     :type name: str


### PR DESCRIPTION
This is a very small change to make methods decorated with `@method()` still return their return values in a local context.  This makes it possible to still use a DBus method locally without having to jump through hoops to obtain the return value.  In my case, I often find myself writing code like this:

```
@method()
def PublicFunction() -> 's':
    return do_PublicFunction()

def do_PublicFunction() -> str:
    return "value"
```

so that I have a way of calling the method locally and obtaining the return value.  Since all the decorator does is add a layer of indirection with an extra `__DBUS_METHOD` attribute on the wrapper, there is no problem with calling it locally if that is desired.
