### PR TITLE
Add message info object

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -38,6 +38,7 @@ class ReadOnlyContextProxy:
     immutable.
     :param name: The name of the context variable.
     """
+
     def __init__(self, name: str):
         self._obj = contextvars.ContextVar(name)
 

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -53,22 +53,7 @@ class ReadOnlyContextProxy:
         self._obj.set(value)
 
 
-current_message = Annotated[
-    ReadOnlyContextProxy("current_message"),
-    """
-The :class:`Message <dbus.message.Message>` object currently being handled.
-Client code can use this to obtain access to details from the message without
-modifying their public API.  Typical use is:
-```
-from dbus_next.message_bus import current_message
-@method()
-def echo_sender() -> 's':
-    return current_message.sender
-```
-Attempts to access any attribute of `current_message` outside of a message context
-will result in a `LookupError` being raised.
-""",
-]
+current_message = ReadOnlyContextProxy("current_message")
 
 
 class BaseMessageBus:

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -5,7 +5,7 @@ import socket
 import traceback
 import xml.etree.ElementTree as ET
 from types import TracebackType
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Annotated, Any, Callable, Dict, List, Optional, Type, Union
 
 from . import introspection as intr
 from ._private.address import get_bus_address, parse_address
@@ -53,7 +53,9 @@ class ReadOnlyContextProxy:
         self._obj.set(value)
 
 
-"""
+current_message = Annotated[
+    ReadOnlyContextProxy("current_message"),
+    """
 The :class:`Message <dbus.message.Message>` object currently being handled.
 Client code can use this to obtain access to details from the message without
 modifying their public API.  Typical use is:
@@ -65,8 +67,8 @@ def echo_sender() -> 's':
 ```
 Attempts to access any attribute of `current_message` outside of a message context
 will result in a `LookupError` being raised.
-"""
-current_message = ReadOnlyContextProxy("current_message")
+""",
+]
 
 
 class BaseMessageBus:

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -10,6 +10,7 @@ from dbus_fast import (
     Variant,
 )
 from dbus_fast.aio import MessageBus
+from dbus_fast.message_bus import current_message
 from dbus_fast.service import ServiceInterface, method
 
 
@@ -33,6 +34,10 @@ class ExampleInterface(ServiceInterface):
     ) -> "asva{sv}(s(s(v)))":
         assert type(self) is ExampleInterface
         return [array, variant, dict_entries, struct]
+
+    @method()
+    def echo_sender(self) -> 's':
+        return current_message.sender
 
     @method()
     def ping(self):
@@ -80,6 +85,10 @@ class AsyncInterface(ServiceInterface):
     ) -> "asva{sv}(s(s(v)))":
         assert type(self) is AsyncInterface
         return [array, variant, dict_entries, struct]
+
+    @method()
+    def echo_sender(self) -> 's':
+        return current_message.sender
 
     @method()
     async def ping(self):
@@ -179,6 +188,10 @@ async def test_methods(interface_class):
 
     reply = await call("throws_dbus_error", flags=MessageFlag.NO_REPLY_EXPECTED)
     assert reply is None
+
+    reply = await call("echo_sender")
+    assert reply.message_type == MessageType.METHOD_RETURN
+    assert reply.signature == "s"
 
     bus1.disconnect()
     bus2.disconnect()

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -36,7 +36,7 @@ class ExampleInterface(ServiceInterface):
         return [array, variant, dict_entries, struct]
 
     @method()
-    def echo_sender(self) -> 's':
+    def echo_sender(self) -> "s":
         return current_message.sender
 
     @method()
@@ -87,7 +87,7 @@ class AsyncInterface(ServiceInterface):
         return [array, variant, dict_entries, struct]
 
     @method()
-    def echo_sender(self) -> 's':
+    def echo_sender(self) -> "s":
         return current_message.sender
 
     @method()


### PR DESCRIPTION
This change adds a context-local variable that exposes the message information in any message handling context.  The new context-local proxy, `current_message`, can be used as though it was the actual `dbus_fast.message.Message` object.  The context-local has its value set at the start of `_process_message`.

I wanted to discuss this change as it's one of the many ways that this information could be exposed to services; but the change is fairly self-contained and easy to understand so the best way of showing what I'm proposing the change is to just raise the PR.  Feedback welcome.