### PR TITLE
feat: only construct handlers once

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -155,7 +155,7 @@ class BaseMessageBus:
                 )
 
         self._path_exports[path].append(interface)
-        ServiceInterface._add_bus(interface, self)
+        ServiceInterface._add_bus(interface, self, path, self._make_method_handler)
         self._emit_interface_added(path, interface)
 
     def unexport(
@@ -196,7 +196,7 @@ class BaseMessageBus:
             del self._path_exports[path]
             for iface in filter(lambda e: not self._has_interface(e), exports):
                 removed_interfaces.append(iface.name)
-                ServiceInterface._remove_bus(iface, self)
+                ServiceInterface._remove_bus(iface, self, path)
         else:
             for i, iface in enumerate(exports):
                 if iface is interface:
@@ -205,7 +205,7 @@ class BaseMessageBus:
                     if not self._path_exports[path]:
                         del self._path_exports[path]
                     if not self._has_interface(iface):
-                        ServiceInterface._remove_bus(iface, self)
+                        ServiceInterface._remove_bus(iface, self, path)
                     break
         self._emit_interface_removed(path, removed_interfaces)
 
@@ -912,7 +912,7 @@ class BaseMessageBus:
                         and msg.member == method.name
                         and msg.signature == method.in_signature
                     ):
-                        handler = self._make_method_handler(interface, method)
+                        handler = ServiceInterface._get_handler(interface, method, self)
                         break
                 if handler:
                     break

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -155,7 +155,7 @@ class BaseMessageBus:
                 )
 
         self._path_exports[path].append(interface)
-        ServiceInterface._add_bus(interface, self, path, self._make_method_handler)
+        ServiceInterface._add_bus(interface, self, self._make_method_handler)
         self._emit_interface_added(path, interface)
 
     def unexport(
@@ -196,7 +196,7 @@ class BaseMessageBus:
             del self._path_exports[path]
             for iface in filter(lambda e: not self._has_interface(e), exports):
                 removed_interfaces.append(iface.name)
-                ServiceInterface._remove_bus(iface, self, path)
+                ServiceInterface._remove_bus(iface, self)
         else:
             for i, iface in enumerate(exports):
                 if iface is interface:
@@ -205,7 +205,7 @@ class BaseMessageBus:
                     if not self._path_exports[path]:
                         del self._path_exports[path]
                     if not self._has_interface(iface):
-                        ServiceInterface._remove_bus(iface, self, path)
+                        ServiceInterface._remove_bus(iface, self)
                     break
         self._emit_interface_removed(path, removed_interfaces)
 

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -155,7 +155,7 @@ class BaseMessageBus:
                 )
 
         self._path_exports[path].append(interface)
-        ServiceInterface._add_bus(interface, self, self._make_method_handler)
+        ServiceInterface._add_bus(interface, self)
         self._emit_interface_added(path, interface)
 
     def unexport(
@@ -862,19 +862,6 @@ class BaseMessageBus:
                 return_handler = self._method_return_handlers[msg.reply_serial]
                 return_handler(msg, None)
             del self._method_return_handlers[msg.reply_serial]
-
-    def _make_method_handler(
-        self, interface: ServiceInterface, method: _Method
-    ) -> Callable[[Message, Callable[[Message], None]], None]:
-        def handler(msg: Message, send_reply: Callable[[Message], None]) -> None:
-            args = ServiceInterface._msg_body_to_args(msg)
-            result = method.fn(interface, *args)
-            body, fds = ServiceInterface._fn_result_to_body(
-                result, signature_tree=method.out_signature_tree
-            )
-            send_reply(Message.new_method_return(msg, method.out_signature, body, fds))
-
-        return handler
 
     def _find_message_handler(
         self, msg: Message

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -13,10 +13,10 @@ from ._private.util import (
 )
 from .constants import PropertyAccess
 from .errors import SignalDisabledError
+from .message import Message
 from .signature import SignatureBodyMismatchError, Variant, get_signature_tree
 
 if TYPE_CHECKING:
-    from .message import Message
     from .message_bus import BaseMessageBus
 
 
@@ -460,7 +460,7 @@ class ServiceInterface:
         bus: "BaseMessageBus",
         maker: Callable[
             ["BaseMessageBus", "ServiceInterface", _Method],
-            Callable[["Message", Callable[["Message"], None]], None],
+            Callable[[Message, Callable[[Message], None]], None],
         ],
     ) -> None:
         interface.__buses.add(bus)

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -459,13 +459,13 @@ class ServiceInterface:
         interface: "ServiceInterface",
         bus: "BaseMessageBus",
         maker: Callable[
-            ["BaseMessageBus", "ServiceInterface", _Method],
+            ["ServiceInterface", _Method],
             Callable[[Message, Callable[[Message], None]], None],
         ],
     ) -> None:
         interface.__buses.add(bus)
         interface.__handlers[bus] = {
-            method: maker(bus, interface, method)
+            method: maker(interface, method)
             for method in ServiceInterface._get_methods(interface)
         }
 

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -460,7 +460,7 @@ class ServiceInterface:
         bus: "BaseMessageBus",
         maker: Callable[
             ["BaseMessageBus", "ServiceInterface", _Method],
-            Callable[[Message, Callable[[Message], None]], None],
+            Callable[["Message", Callable[["Message"], None]], None],
         ],
     ) -> None:
         interface.__buses.add(bus)

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -13,10 +13,10 @@ from ._private.util import (
 )
 from .constants import PropertyAccess
 from .errors import SignalDisabledError
-from .message import Message
 from .signature import SignatureBodyMismatchError, Variant, get_signature_tree
 
 if TYPE_CHECKING:
+    from .message import Message
     from .message_bus import BaseMessageBus
 
 
@@ -433,20 +433,6 @@ class ServiceInterface:
         )
 
     @staticmethod
-    def _make_method_handler(
-        interface: "ServiceInterface", method: _Method
-    ) -> Callable[[Message, Callable[[Message], None]], None]:
-        def handler(msg: Message, send_reply: Callable[[Message], None]) -> None:
-            args = ServiceInterface._msg_body_to_args(msg)
-            result = method.fn(interface, *args)
-            body, fds = ServiceInterface._fn_result_to_body(
-                result, signature_tree=method.out_signature_tree
-            )
-            send_reply(Message.new_method_return(msg, method.out_signature, body, fds))
-
-        return handler
-
-    @staticmethod
     def _get_properties(interface: "ServiceInterface") -> List[_Property]:
         return interface.__properties
 
@@ -472,12 +458,15 @@ class ServiceInterface:
     def _add_bus(
         interface: "ServiceInterface",
         bus: "BaseMessageBus",
+        maker: Callable[
+            ["BaseMessageBus", "ServiceInterface", _Method],
+            Callable[["Message", Callable[["Message"], None]], None],
+        ],
     ) -> None:
         interface.__buses.add(bus)
-        interface.__handlers[bus] = {
-            method: ServiceInterface._make_method_handler(interface, method)
-            for method in ServiceInterface._get_methods(interface)
-        }
+        for method in ServiceInterface._get_methods(interface):
+            handler = maker(bus, interface, method)
+            interface.__handlers.setdefault(bus, {})[method] = handler
 
     @staticmethod
     def _remove_bus(interface: "ServiceInterface", bus: "BaseMessageBus") -> None:

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -457,10 +457,9 @@ class ServiceInterface:
     @staticmethod
     def _add_bus(
         interface: "ServiceInterface",
-        bus: BaseMessageBus,
-        path: str,
+        bus: "BaseMessageBus",
         maker: Callable[
-            [BaseMessageBus, "ServiceInterface", _Method],
+            ["BaseMessageBus", "ServiceInterface", _Method],
             Callable[[Message, Callable[[Message], None]], None],
         ],
     ) -> None:
@@ -470,9 +469,7 @@ class ServiceInterface:
             interface.__handlers.setdefault(bus, {})[method] = handler
 
     @staticmethod
-    def _remove_bus(
-        interface: "ServiceInterface", bus: BaseMessageBus, path: str
-    ) -> None:
+    def _remove_bus(interface: "ServiceInterface", bus: "BaseMessageBus") -> None:
         interface.__buses.remove(bus)
         del interface.__handlers[bus]
 

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -465,8 +465,7 @@ class ServiceInterface:
     ) -> None:
         interface.__buses.add(bus)
         interface.__handlers[bus] = {
-            method: maker(interface, method)
-            for method in ServiceInterface._get_methods(interface)
+            method: maker(interface, method) for method in interface.__methods
         }
 
     @staticmethod

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -450,7 +450,7 @@ class ServiceInterface:
 
     @staticmethod
     def _get_handler(
-        interface: "ServiceInterface", method: _Method, bus: BaseMessageBus
+        interface: "ServiceInterface", method: _Method, bus: "BaseMessageBus"
     ):
         return interface.__handlers[bus][method]
 

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -2,7 +2,15 @@ import asyncio
 import copy
 import inspect
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, no_type_check_decorator
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Set,
+    no_type_check_decorator,
+)
 
 from . import introspection as intr
 from ._private.util import (
@@ -445,13 +453,13 @@ class ServiceInterface:
         return interface.__signals
 
     @staticmethod
-    def _get_buses(interface: "ServiceInterface"):
+    def _get_buses(interface: "ServiceInterface") -> Set["BaseMessageBus"]:
         return interface.__buses
 
     @staticmethod
     def _get_handler(
         interface: "ServiceInterface", method: _Method, bus: "BaseMessageBus"
-    ):
+    ) -> Callable[[Message, Callable[[Message], None]], None]:
         return interface.__handlers[bus][method]
 
     @staticmethod

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -464,9 +464,10 @@ class ServiceInterface:
         ],
     ) -> None:
         interface.__buses.add(bus)
-        for method in ServiceInterface._get_methods(interface):
-            handler = maker(bus, interface, method)
-            interface.__handlers.setdefault(bus, {})[method] = handler
+        interface.__handlers[bus] = {
+            method: maker(bus, interface, method)
+            for method in ServiceInterface._get_methods(interface)
+        }
 
     @staticmethod
     def _remove_bus(interface: "ServiceInterface", bus: "BaseMessageBus") -> None:


### PR DESCRIPTION
When bleak is using passive scanning each message would cause a method handler to be constructed via `_make_method_handler`

Only construct them once.