### PR TITLE
feat: add support for EXTERNAL auth without uid

### DIFF
--- a/src/dbus_fast/auth.py
+++ b/src/dbus_fast/auth.py
@@ -68,6 +68,8 @@ class AuthExternal(Authenticator):
     def _authentication_start(self, negotiate_unix_fd: bool = False) -> str:
         self.negotiate_unix_fd = negotiate_unix_fd
         uid = self.uid
+        if uid == -1:
+            return "AUTH EXTERNAL"
         if uid is None:
             uid = os.getuid()
         hex_uid = str(uid).encode().hex()
@@ -85,6 +87,9 @@ class AuthExternal(Authenticator):
 
         if response is _AuthResponse.AGREE_UNIX_FD:
             return "BEGIN"
+
+        if response is _AuthResponse.DATA and self.uid == -1:
+            return _AuthResponse.DATA
 
         raise AuthError(f"authentication failed: {response.value}: {args}")
 

--- a/src/dbus_fast/auth.py
+++ b/src/dbus_fast/auth.py
@@ -59,6 +59,9 @@ class AuthExternal(Authenticator):
     """An authenticator class for the external auth protocol for use with the
     :class:`MessageBus <dbus_fast.message_bus.BaseMessageBus>`.
 
+    :param uid: The uid to use when connecting to the message bus. Use UID_NOT_SPECIFIED to use the uid known to the kernel.
+    :vartype uid: int
+
     :sealso: https://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol
     """
 

--- a/src/dbus_fast/auth.py
+++ b/src/dbus_fast/auth.py
@@ -89,7 +89,7 @@ class AuthExternal(Authenticator):
             return "BEGIN"
 
         if response is _AuthResponse.DATA and self.uid == -1:
-            return _AuthResponse.DATA
+            return "DATA"
 
         raise AuthError(f"authentication failed: {response.value}: {args}")
 

--- a/src/dbus_fast/auth.py
+++ b/src/dbus_fast/auth.py
@@ -4,6 +4,8 @@ from typing import List, Optional, Tuple
 
 from .errors import AuthError
 
+UID_NOT_SPECIFIED = -1
+
 # The auth interface here is unstable. I would like to eventually open this up
 # for people to define their own custom authentication protocols, but I'm not
 # familiar with what's needed for that exactly. To work with any message bus
@@ -68,7 +70,7 @@ class AuthExternal(Authenticator):
     def _authentication_start(self, negotiate_unix_fd: bool = False) -> str:
         self.negotiate_unix_fd = negotiate_unix_fd
         uid = self.uid
-        if uid == -1:
+        if uid == UID_NOT_SPECIFIED:
             return "AUTH EXTERNAL"
         if uid is None:
             uid = os.getuid()
@@ -88,7 +90,7 @@ class AuthExternal(Authenticator):
         if response is _AuthResponse.AGREE_UNIX_FD:
             return "BEGIN"
 
-        if response is _AuthResponse.DATA and self.uid == -1:
+        if response is _AuthResponse.DATA and self.uid == UID_NOT_SPECIFIED:
             return "DATA"
 
         raise AuthError(f"authentication failed: {response.value}: {args}")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,3 +14,4 @@ def test_uid_is_set():
 def test_no_uid():
     auth = AuthExternal(uid=-1)
     assert auth._authentication_start() == "AUTH EXTERNAL"
+    assert auth._receive_line("DATA") == "DATA"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from dbus_fast.auth import UID_NOT_SPECIFIED, AuthExternal
+from dbus_fast.errors import AuthError
 
 
 def test_uid_is_set():
@@ -11,7 +12,10 @@ def test_uid_is_set():
     assert auth._authentication_start() == "AUTH EXTERNAL 393939"
 
 
-def test_no_uid():
+def test_auth_external_no_uid():
+    """Test AuthExternal with UID_NOT_SPECIFIED"""
     auth = AuthExternal(uid=UID_NOT_SPECIFIED)
     assert auth._authentication_start() == "AUTH EXTERNAL"
     assert auth._receive_line("DATA") == "DATA"
+    with pytest.raises(AuthError):
+        auth._receive_line("REJECTED")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,3 +9,8 @@ from dbus_fast.auth import AuthExternal
 def test_uid_is_set():
     auth = AuthExternal(uid=999)
     assert auth._authentication_start() == "AUTH EXTERNAL 393939"
+
+
+def test_no_uid():
+    auth = AuthExternal(uid=-1)
+    assert auth._authentication_start() == "AUTH EXTERNAL"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from dbus_fast.auth import AuthExternal
+from dbus_fast.auth import AuthExternal, UID_NOT_SPECIFIED
 
 
 def test_uid_is_set():
@@ -12,6 +12,6 @@ def test_uid_is_set():
 
 
 def test_no_uid():
-    auth = AuthExternal(uid=-1)
+    auth = AuthExternal(uid=UID_NOT_SPECIFIED)
     assert auth._authentication_start() == "AUTH EXTERNAL"
     assert auth._receive_line("DATA") == "DATA"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 
-from dbus_fast.auth import AuthExternal, UID_NOT_SPECIFIED
+from dbus_fast.auth import UID_NOT_SPECIFIED, AuthExternal
 
 
 def test_uid_is_set():


### PR DESCRIPTION
As a follow-up to #188 , this PR allows `EXTERNAL` auth without a uid as per RFC4422. If we pass `-1` as the uid, it will trigger the following auth sequence (source: https://gitlab.freedesktop.org/dbus/dbus/-/issues/195):
```
C: AUTH EXTERNAL            # I want to use EXTERNAL, but I do not
                            # have an initial response
S: DATA                     # Who do you claim you are?
C: DATA                     # Whoever the kernel says I am
S: OK                       # Can't argue with that!
```
The upside of this is that when running in a user namespace (e.g. rootless docker), we don't need to know our uid mapping outside of the namespace to connect to the system dbus on the host.