### PR TITLE
feat: speed up unmarshaller by avoiding unicode strings

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -107,7 +107,7 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     return u16p[0]
 
 cdef inline cython.str _cast_unicode(const char * value):
-    return value.decode('utf-8')
+    return (<bytes>value).decode('utf-8')
 
 cdef cython.str _as_pystring(const char * value)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -171,6 +171,7 @@ cdef class Unmarshaller:
 
     @cython.locals(
         tree=SignatureTree,
+        bytes_string=cython.bytes,
     )
     cdef Variant _read_variant(self)
 
@@ -183,6 +184,9 @@ cdef class Unmarshaller:
     )
     cdef object _read_array(self, SignatureType type_)
 
+    @cython.locals(
+        bytes_string=cython.bytes,
+    )
     cpdef read_signature(self, SignatureType type_)
 
     @cython.locals(
@@ -213,5 +217,6 @@ cdef class Unmarshaller:
         o=cython.ulong,
         token_as_int=cython.uint,
         signature_len=cython.uint,
+        bytes_string=cython.bytes,
     )
     cdef cython.dict _header_fields(self, unsigned int header_length)

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -106,7 +106,7 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     cdef unsigned short *u16p = <unsigned short *> &payload[offset]
     return u16p[0]
 
-cdef cython.str _as_unicode_string(const char * value)
+cdef cython.str _as_latin1_string(const char * value)
 
 
 cdef class Unmarshaller:

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -106,8 +106,8 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     cdef unsigned short *u16p = <unsigned short *> &payload[offset]
     return u16p[0]
 
-cdef inline cython.str _cast_unicode(const char * value):
-    return (<bytes>value).decode('utf-8')
+cdef inline cython.str _cast_bytes_decode_utf8(const char * value):
+    return (<bytes>value).encode('utf-8')
 
 cdef cython.str _as_pystring(const char * value)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -1,7 +1,5 @@
 """cdefs for unmarshaller.py"""
 
-# cython: c_string_type=unicode, c_string_encoding=utf8
-
 
 import cython
 
@@ -109,11 +107,6 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     cdef unsigned short *u16p = <unsigned short *> &payload[offset]
     return u16p[0]
 
-cdef inline cython.str _cast_bytes_decode_utf8(const char * value):
-    return (<bytes>value).decode('utf-8')
-
-cdef cython.str _as_pystring(const char * value)
-
 
 cdef class Unmarshaller:
 
@@ -178,6 +171,7 @@ cdef class Unmarshaller:
 
     @cython.locals(
         tree=SignatureTree,
+        signature_char=cython.p_char
     )
     cdef Variant _read_variant(self)
 
@@ -196,7 +190,7 @@ cdef class Unmarshaller:
         o=cython.ulong,
         signature_len=cython.uint,
     )
-    cdef char * _read_signature(self)
+    cdef str _read_signature(self)
 
     @cython.locals(
         endian=cython.uint,

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -106,7 +106,10 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     cdef unsigned short *u16p = <unsigned short *> &payload[offset]
     return u16p[0]
 
-cdef inline cython.str _as_pystring(const char * value)
+cdef inline _cast_unicode(const char * value):
+    return <unicode> value
+
+cdef cython.str _as_pystring(const char * value)
 
 
 cdef class Unmarshaller:

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -106,6 +106,7 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     cdef unsigned short *u16p = <unsigned short *> &payload[offset]
     return u16p[0]
 
+cdef cython.str _as_unicode_string(const char * value)
 
 
 cdef class Unmarshaller:

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -106,8 +106,8 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     cdef unsigned short *u16p = <unsigned short *> &payload[offset]
     return u16p[0]
 
-cdef inline _cast_unicode(const char * value):
-    return <unicode> value
+cdef inline cython.str _cast_unicode(const char * value):
+    return value.decode('utf-8')
 
 cdef cython.str _as_pystring(const char * value)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -73,6 +73,18 @@ cdef SignatureType SIGNATURE_TREE_A_QV_TYPES_0
 cdef SignatureTree SIGNATURE_TREE_A_OA_SA_SV
 cdef SignatureType SIGNATURE_TREE_A_OA_SA_SV_TYPES_0
 
+cdef char * SIGNATURE_N_BYTES
+cdef char * SIGNATURE_AY_BYTES
+cdef char * SIGNATURE_A_QV_BYTES
+cdef char * SIGNATURE_S_BYTES
+cdef char * SIGNATURE_B_BYTES
+cdef char * SIGNATURE_O_BYTES
+cdef char * SIGNATURE_AS_BYTES
+cdef char * SIGNATURE_A_SV_BYTES
+cdef char * SIGNATURE_AO_BYTES
+cdef char * SIGNATURE_U_BYTES
+cdef char * SIGNATURE_Y_BYTES
+
 cdef unsigned int TOKEN_O_AS_INT
 cdef unsigned int TOKEN_S_AS_INT
 cdef unsigned int TOKEN_G_AS_INT
@@ -177,7 +189,7 @@ cdef class Unmarshaller:
         o=cython.ulong,
         signature_len=cython.uint,
     )
-    cdef str _read_signature(self)
+    cdef char * _read_signature(self)
 
     @cython.locals(
         endian=cython.uint,

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -1,5 +1,8 @@
 """cdefs for unmarshaller.py"""
 
+# cython: c_string_type=unicode, c_string_encoding=utf8
+
+
 import cython
 
 from ..message cimport Message

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -106,7 +106,7 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     cdef unsigned short *u16p = <unsigned short *> &payload[offset]
     return u16p[0]
 
-cdef cython.str _as_latin1_string(const char * value)
+cdef inline cython.str _as_pystring(const char * value)
 
 
 cdef class Unmarshaller:

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -175,7 +175,6 @@ cdef class Unmarshaller:
 
     @cython.locals(
         tree=SignatureTree,
-        bytes_string=cython.bytes,
     )
     cdef Variant _read_variant(self)
 
@@ -188,9 +187,6 @@ cdef class Unmarshaller:
     )
     cdef object _read_array(self, SignatureType type_)
 
-    @cython.locals(
-        bytes_string=cython.bytes,
-    )
     cpdef read_signature(self, SignatureType type_)
 
     @cython.locals(
@@ -221,6 +217,5 @@ cdef class Unmarshaller:
         o=cython.ulong,
         token_as_int=cython.uint,
         signature_len=cython.uint,
-        bytes_string=cython.bytes,
     )
     cdef cython.dict _header_fields(self, unsigned int header_length)

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -107,7 +107,7 @@ cdef inline unsigned short _cast_uint16_native(const char *  payload, unsigned i
     return u16p[0]
 
 cdef inline cython.str _cast_bytes_decode_utf8(const char * value):
-    return (<bytes>value).encode('utf-8')
+    return (<bytes>value).decode('utf-8')
 
 cdef cython.str _as_pystring(const char * value)
 

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -185,7 +185,7 @@ _bytes = bytes
 
 def _as_pystring(value: _bytes) -> str:
     if cython.compiled:  # pragma: no cover
-        return _cast_unicode(value)  # type: ignore[name-defined] # pragma: no cover
+        return _cast_bytes_decode_utf8(value)  # type: ignore[name-defined] # pragma: no cover
     return value.decode()
 
 

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -415,7 +415,7 @@ class Unmarshaller:
         elif signature_char == SIGNATURE_Y_BYTES:
             self._pos += 1
             return Variant(SIGNATURE_TREE_Y, self._buf[self._pos - 1], False)
-        tree = get_signature_tree(signature_bytes.decode())
+        tree = get_signature_tree(signature)
         signature_type = tree.types[0]
         return Variant(
             tree,

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -359,7 +359,7 @@ class Unmarshaller:
         return self._buf[str_start : self._pos - 1].decode()
 
     def read_signature(self, type_: _SignatureType) -> str:
-        return self._read_signature().decode()
+        return bytes(self._read_signature()).decode()
 
     def _read_signature(self) -> bytes:
         signature_len = self._buf[self._pos]  # byte
@@ -411,7 +411,7 @@ class Unmarshaller:
         elif signature == SIGNATURE_Y_BYTES:
             self._pos += 1
             return Variant(SIGNATURE_TREE_Y, self._buf[self._pos - 1], False)
-        tree = get_signature_tree(signature.decode())
+        tree = get_signature_tree(bytes(signature).decode())
         signature_type = tree.types[0]
         return Variant(
             tree,

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -183,7 +183,7 @@ except ImportError:
 _bytes = bytes
 
 
-def _as_unicode_string(value: _bytes) -> str:
+def _as_ascii_string(value: _bytes) -> str:
     return value.decode("ascii")
 
 
@@ -366,7 +366,7 @@ class Unmarshaller:
         return self._buf[str_start : self._pos - 1].decode()
 
     def read_signature(self, type_: _SignatureType) -> str:
-        return _as_unicode_string(self._read_signature())
+        return _as_ascii_string(self._read_signature())
 
     def _read_signature(self) -> bytes:
         signature_len = self._buf[self._pos]  # byte
@@ -418,7 +418,7 @@ class Unmarshaller:
         elif signature == SIGNATURE_Y_BYTES:
             self._pos += 1
             return Variant(SIGNATURE_TREE_Y, self._buf[self._pos - 1], False)
-        tree = get_signature_tree(_as_unicode_string(signature))
+        tree = get_signature_tree(_as_ascii_string(signature))
         signature_type = tree.types[0]
         return Variant(
             tree,
@@ -541,7 +541,7 @@ class Unmarshaller:
             if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:
                 headers[key] = self._read_string_unpack()
             elif token_as_int == TOKEN_G_AS_INT:
-                headers[key] = _as_unicode_string(self._read_signature())
+                headers[key] = _as_ascii_string(self._read_signature())
             else:
                 token = buf[o : o + signature_len].decode()
                 # There shouldn't be any other types in the header

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -359,7 +359,8 @@ class Unmarshaller:
         return self._buf[str_start : self._pos - 1].decode()
 
     def read_signature(self, type_: _SignatureType) -> str:
-        return bytes(self._read_signature()).decode()
+        bytes_string = bytes(self._read_signature())
+        return bytes_string.decode()
 
     def _read_signature(self) -> bytes:
         signature_len = self._buf[self._pos]  # byte
@@ -411,7 +412,8 @@ class Unmarshaller:
         elif signature == SIGNATURE_Y_BYTES:
             self._pos += 1
             return Variant(SIGNATURE_TREE_Y, self._buf[self._pos - 1], False)
-        tree = get_signature_tree(bytes(signature).decode())
+        bytes_string = bytes(signature)
+        tree = get_signature_tree(bytes_string.decode())
         signature_type = tree.types[0]
         return Variant(
             tree,
@@ -534,7 +536,8 @@ class Unmarshaller:
             if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:
                 headers[key] = self._read_string_unpack()
             elif token_as_int == TOKEN_G_AS_INT:
-                headers[key] = self._read_signature().decode()
+                bytes_string = bytes(self._read_signature())
+                headers[key] = bytes_string.decode()
             else:
                 token = buf[o : o + signature_len].decode()
                 # There shouldn't be any other types in the header

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -184,6 +184,8 @@ _bytes = bytes
 
 
 def _as_pystring(value: _bytes) -> str:
+    if cython.compiled:  # pragma: no cover
+        return _cast_unicode(value)  # type: ignore[name-defined] # pragma: no cover
     return value.decode()
 
 

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -183,8 +183,8 @@ except ImportError:
 _bytes = bytes
 
 
-def _as_ascii_string(value: _bytes) -> str:
-    return value.decode("ascii")
+def _as_latin1_string(value: _bytes) -> str:
+    return value.decode("latin-1")
 
 
 class Unmarshaller:
@@ -366,7 +366,7 @@ class Unmarshaller:
         return self._buf[str_start : self._pos - 1].decode()
 
     def read_signature(self, type_: _SignatureType) -> str:
-        return _as_ascii_string(self._read_signature())
+        return _as_latin1_string(self._read_signature())
 
     def _read_signature(self) -> bytes:
         signature_len = self._buf[self._pos]  # byte
@@ -418,7 +418,7 @@ class Unmarshaller:
         elif signature == SIGNATURE_Y_BYTES:
             self._pos += 1
             return Variant(SIGNATURE_TREE_Y, self._buf[self._pos - 1], False)
-        tree = get_signature_tree(_as_ascii_string(signature))
+        tree = get_signature_tree(_as_latin1_string(signature))
         signature_type = tree.types[0]
         return Variant(
             tree,
@@ -541,7 +541,7 @@ class Unmarshaller:
             if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:
                 headers[key] = self._read_string_unpack()
             elif token_as_int == TOKEN_G_AS_INT:
-                headers[key] = _as_ascii_string(self._read_signature())
+                headers[key] = _as_latin1_string(self._read_signature())
             else:
                 token = buf[o : o + signature_len].decode()
                 # There shouldn't be any other types in the header

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -183,8 +183,8 @@ except ImportError:
 _bytes = bytes
 
 
-def _as_latin1_string(value: _bytes) -> str:
-    return value.decode("latin-1")
+def _as_pystring(value: _bytes) -> str:
+    return value.decode()
 
 
 class Unmarshaller:
@@ -366,7 +366,7 @@ class Unmarshaller:
         return self._buf[str_start : self._pos - 1].decode()
 
     def read_signature(self, type_: _SignatureType) -> str:
-        return _as_latin1_string(self._read_signature())
+        return _as_pystring(self._read_signature())
 
     def _read_signature(self) -> bytes:
         signature_len = self._buf[self._pos]  # byte
@@ -418,7 +418,7 @@ class Unmarshaller:
         elif signature == SIGNATURE_Y_BYTES:
             self._pos += 1
             return Variant(SIGNATURE_TREE_Y, self._buf[self._pos - 1], False)
-        tree = get_signature_tree(_as_latin1_string(signature))
+        tree = get_signature_tree(_as_pystring(signature))
         signature_type = tree.types[0]
         return Variant(
             tree,
@@ -541,7 +541,7 @@ class Unmarshaller:
             if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:
                 headers[key] = self._read_string_unpack()
             elif token_as_int == TOKEN_G_AS_INT:
-                headers[key] = _as_latin1_string(self._read_signature())
+                headers[key] = _as_pystring(self._read_signature())
             else:
                 token = buf[o : o + signature_len].decode()
                 # There shouldn't be any other types in the header

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -94,6 +94,19 @@ SIGNATURE_TREE_OA_SA_SV_TYPES_1 = SIGNATURE_TREE_OA_SA_SV.types[1]
 SIGNATURE_TREE_A_OA_SA_SV = get_signature_tree("a{oa{sa{sv}}}")
 SIGNATURE_TREE_A_OA_SA_SV_TYPES_0 = SIGNATURE_TREE_A_OA_SA_SV.types[0]
 
+SIGNATURE_N_BYTES = "n"
+SIGNATURE_AY_BYTES = "ay"
+SIGNATURE_A_QV_BYTES = "a{qv}"
+SIGNATURE_S_BYTES = "s"
+SIGNATURE_B_BYTES = "b"
+SIGNATURE_O_BYTES = "o"
+SIGNATURE_AS_BYTES = "as"
+SIGNATURE_A_SV_BYTES = "a{sv}"
+SIGNATURE_AO_BYTES = "ao"
+SIGNATURE_U_BYTES = "u"
+SIGNATURE_Y_BYTES = "y"
+
+
 TOKEN_O_AS_INT = ord("o")
 TOKEN_S_AS_INT = ord("s")
 TOKEN_G_AS_INT = ord("g")
@@ -346,14 +359,14 @@ class Unmarshaller:
         return self._buf[str_start : self._pos - 1].decode()
 
     def read_signature(self, type_: _SignatureType) -> str:
-        return self._read_signature()
+        return self._read_signature().decode()
 
-    def _read_signature(self) -> str:
+    def _read_signature(self) -> bytes:
         signature_len = self._buf[self._pos]  # byte
         o = self._pos + 1
         # read terminating '\0' byte as well (str_length + 1)
         self._pos = o + signature_len + 1
-        return self._buf[o : o + signature_len].decode()
+        return self._buf[o : o + signature_len]
 
     def read_variant(self, type_: _SignatureType) -> Variant:
         return self._read_variant()
@@ -361,44 +374,44 @@ class Unmarshaller:
     def _read_variant(self) -> Variant:
         signature = self._read_signature()
         # verify in Variant is only useful on construction not unmarshalling
-        if signature == "n":
+        if signature == SIGNATURE_N_BYTES:
             return Variant(SIGNATURE_TREE_N, self._read_int16_unpack(), False)
-        elif signature == "ay":
+        elif signature == SIGNATURE_AY_BYTES:
             return Variant(
                 SIGNATURE_TREE_AY, self._read_array(SIGNATURE_TREE_AY_TYPES_0), False
             )
-        elif signature == "a{qv}":
+        elif signature == SIGNATURE_A_QV_BYTES:
             return Variant(
                 SIGNATURE_TREE_A_QV,
                 self._read_array(SIGNATURE_TREE_A_QV_TYPES_0),
                 False,
             )
-        elif signature == "s":
+        elif signature == SIGNATURE_S_BYTES:
             return Variant(SIGNATURE_TREE_S, self._read_string_unpack(), False)
-        elif signature == "b":
+        elif signature == SIGNATURE_B_BYTES:
             return Variant(SIGNATURE_TREE_B, self._read_boolean(), False)
-        elif signature == "o":
+        elif signature == SIGNATURE_O_BYTES:
             return Variant(SIGNATURE_TREE_O, self._read_string_unpack(), False)
-        elif signature == "as":
+        elif signature == SIGNATURE_AS_BYTES:
             return Variant(
                 SIGNATURE_TREE_AS, self._read_array(SIGNATURE_TREE_AS_TYPES_0), False
             )
-        elif signature == "a{sv}":
+        elif signature == SIGNATURE_A_SV_BYTES:
             return Variant(
                 SIGNATURE_TREE_A_SV,
                 self._read_array(SIGNATURE_TREE_A_SV_TYPES_0),
                 False,
             )
-        elif signature == "ao":
+        elif signature == SIGNATURE_AO_BYTES:
             return Variant(
                 SIGNATURE_TREE_AO, self._read_array(SIGNATURE_TREE_AO_TYPES_0), False
             )
-        elif signature == "u":
+        elif signature == SIGNATURE_U_BYTES:
             return Variant(SIGNATURE_TREE_U, self._read_uint32_unpack(), False)
-        elif signature == "y":
+        elif signature == SIGNATURE_Y_BYTES:
             self._pos += 1
             return Variant(SIGNATURE_TREE_Y, self._buf[self._pos - 1], False)
-        tree = get_signature_tree(signature)
+        tree = get_signature_tree(signature.decode())
         signature_type = tree.types[0]
         return Variant(
             tree,
@@ -521,7 +534,7 @@ class Unmarshaller:
             if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:
                 headers[key] = self._read_string_unpack()
             elif token_as_int == TOKEN_G_AS_INT:
-                headers[key] = self._read_signature()
+                headers[key] = self._read_signature().decode()
             else:
                 token = buf[o : o + signature_len].decode()
                 # There shouldn't be any other types in the header

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -180,7 +180,6 @@ except ImportError:
 #    (-pos) & (align - 1)
 #
 #
-_bytes = bytes
 
 
 class Unmarshaller:
@@ -364,7 +363,7 @@ class Unmarshaller:
     def read_signature(self, type_: _SignatureType) -> str:
         return self._read_signature()
 
-    def _read_signature(self) -> bytearray:
+    def _read_signature(self) -> str:
         signature_len = self._buf[self._pos]  # byte
         o = self._pos + 1
         # read terminating '\0' byte as well (str_length + 1)

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -184,7 +184,7 @@ _bytes = bytes
 
 
 def _as_unicode_string(value: _bytes) -> str:
-    return value.decode("utf-8")
+    return value.decode("ascii")
 
 
 class Unmarshaller:

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -180,6 +180,13 @@ except ImportError:
 #    (-pos) & (align - 1)
 #
 #
+_bytes = bytes
+
+
+def _as_unicode_string(value: _bytes) -> str:
+    return value.decode("utf-8")
+
+
 class Unmarshaller:
 
     __slots__ = (
@@ -359,8 +366,7 @@ class Unmarshaller:
         return self._buf[str_start : self._pos - 1].decode()
 
     def read_signature(self, type_: _SignatureType) -> str:
-        bytes_string = bytes(self._read_signature())
-        return bytes_string.decode()
+        return _as_unicode_string(self._read_signature())
 
     def _read_signature(self) -> bytes:
         signature_len = self._buf[self._pos]  # byte
@@ -412,8 +418,7 @@ class Unmarshaller:
         elif signature == SIGNATURE_Y_BYTES:
             self._pos += 1
             return Variant(SIGNATURE_TREE_Y, self._buf[self._pos - 1], False)
-        bytes_string = bytes(signature)
-        tree = get_signature_tree(bytes_string.decode())
+        tree = get_signature_tree(_as_unicode_string(signature))
         signature_type = tree.types[0]
         return Variant(
             tree,
@@ -536,8 +541,7 @@ class Unmarshaller:
             if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:
                 headers[key] = self._read_string_unpack()
             elif token_as_int == TOKEN_G_AS_INT:
-                bytes_string = bytes(self._read_signature())
-                headers[key] = bytes_string.decode()
+                headers[key] = _as_unicode_string(self._read_signature())
             else:
                 token = buf[o : o + signature_len].decode()
                 # There shouldn't be any other types in the header


### PR DESCRIPTION
This is ~14% speed up against the benchmark, and we can do the same in a few more places