### PR TITLE
fix: relax typing on _fn_result_to_body to allow Any

### DIFF
--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -504,7 +504,7 @@ class ServiceInterface:
 
     @staticmethod
     def _fn_result_to_body(
-        result: List[Any], signature_tree: SignatureTree, replace_fds: bool = True
+        result: Any, signature_tree: SignatureTree, replace_fds: bool = True
     ) -> Tuple[List[Any], List[int]]:
         """The high level interfaces may return single values which may be
         wrapped in a list to be a message body. Also they may return fds


### PR DESCRIPTION
another cython3 fix for incorrect typing