### PR TITLE
fix: avoid double buffering when using asyncio reader without negotiate_unix_fd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             REQUIRE_CYTHON=1 poetry install --only=main,dev
           fi
       - name: Test with Pytest
-        run: export $(dbus-launch); poetry run pytest --cov-report=xml --timeout=5
+        run: export $(dbus-launch); poetry run pytest  -vvvs --cov-report=xml --timeout=5
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             REQUIRE_CYTHON=1 poetry install --only=main,dev
           fi
       - name: Test with Pytest
-        run: export $(dbus-launch); poetry run pytest  -vvvs --cov-report=xml --timeout=5
+        run: export $(dbus-launch); poetry run pytest --cov-report=xml --timeout=5
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/bench/unmarshall.py
+++ b/bench/unmarshall.py
@@ -23,7 +23,7 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarhsall_bluez_rssi_message():
     stream.seek(0)
-    unmarshaller.reset()
+    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall.py
+++ b/bench/unmarshall.py
@@ -23,7 +23,6 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarhsall_bluez_rssi_message():
     stream.seek(0)
-    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_2.py
+++ b/bench/unmarshall_2.py
@@ -42,7 +42,6 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarhsall_bluez_rssi_message():
     stream.seek(0)
-    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_2.py
+++ b/bench/unmarshall_2.py
@@ -42,7 +42,7 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarhsall_bluez_rssi_message():
     stream.seek(0)
-    unmarshaller.reset()
+    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_getmanagedobjects.py
+++ b/bench/unmarshall_getmanagedobjects.py
@@ -16,7 +16,7 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarhsall_bluez_get_managed_objects_message():
     stream.seek(0)
-    unmarshaller.reset()
+    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_getmanagedobjects.py
+++ b/bench/unmarshall_getmanagedobjects.py
@@ -16,7 +16,6 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarhsall_bluez_get_managed_objects_message():
     stream.seek(0)
-    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_interfaces_added.py
+++ b/bench/unmarshall_interfaces_added.py
@@ -31,7 +31,7 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarshall_interfaces_added_message():
     stream.seek(0)
-    unmarshaller.reset()
+    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_interfaces_added.py
+++ b/bench/unmarshall_interfaces_added.py
@@ -31,7 +31,6 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarshall_interfaces_added_message():
     stream.seek(0)
-    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_interfaces_removed.py
+++ b/bench/unmarshall_interfaces_removed.py
@@ -22,7 +22,6 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarshall_interfaces_removed_message():
     stream.seek(0)
-    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_interfaces_removed.py
+++ b/bench/unmarshall_interfaces_removed.py
@@ -22,7 +22,7 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarshall_interfaces_removed_message():
     stream.seek(0)
-    unmarshaller.reset()
+    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_manufacturerdata.py
+++ b/bench/unmarshall_manufacturerdata.py
@@ -21,7 +21,7 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarshall_mfr_data_message():
     stream.seek(0)
-    unmarshaller.reset()
+    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_manufacturerdata.py
+++ b/bench/unmarshall_manufacturerdata.py
@@ -21,7 +21,6 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarshall_mfr_data_message():
     stream.seek(0)
-    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_passive.py
+++ b/bench/unmarshall_passive.py
@@ -20,7 +20,6 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarhsall_bluez_rssi_message():
     stream.seek(0)
-    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_passive.py
+++ b/bench/unmarshall_passive.py
@@ -20,7 +20,7 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarhsall_bluez_rssi_message():
     stream.seek(0)
-    unmarshaller.reset()
+    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_servicedata.py
+++ b/bench/unmarshall_servicedata.py
@@ -23,7 +23,6 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarshall_properties_changed_message():
     stream.seek(0)
-    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/bench/unmarshall_servicedata.py
+++ b/bench/unmarshall_servicedata.py
@@ -23,7 +23,7 @@ unmarshaller = Unmarshaller(stream)
 
 def unmarshall_properties_changed_message():
     stream.seek(0)
-    unmarshaller.reset()
+    unmarshaller.next_message()
     unmarshaller.unmarshall()
 
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -117,7 +117,7 @@ cdef class Unmarshaller:
     cdef object _int16_unpack
     cdef object _uint16_unpack
     cdef object _stream_reader
-    cdef object _negotiate_unix_fd
+    cdef bint _negotiate_unix_fd
 
     cpdef next_message(self)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -119,7 +119,7 @@ cdef class Unmarshaller:
     cdef object _stream_reader
     cdef object _negotiate_unix_fd
 
-    cdef _reset(self)
+    cdef _next_message(self)
 
     @cython.locals(
         data=cython.bytes,

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -127,7 +127,7 @@ cdef class Unmarshaller:
     cdef _next_message(self)
 
     @cython.locals(
-        data=cython.bytes,
+        msg=cython.bytes,
         recv=cython.tuple,
         errno=cython.uint
     )

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -125,7 +125,7 @@ cdef class Unmarshaller:
 
     cdef _next_message(self)
 
-    cdef _has_data_in_buffer(self)
+    cdef _has_another_message_in_buffer(self)
 
     @cython.locals(
         msg=cython.bytes,

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -140,10 +140,9 @@ cdef class Unmarshaller:
     cdef _read_sock_without_fds(self, unsigned int pos)
 
     @cython.locals(
-        missing_bytes=cython.uint,
         data=cython.bytes
     )
-    cdef _read_stream(self, unsigned int pos)
+    cdef _read_stream(self, unsigned int pos, unsigned int missing_bytes)
 
     cdef _read_to_pos(self, unsigned int pos)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -121,8 +121,7 @@ cdef class Unmarshaller:
     cdef object _uint16_unpack
     cdef object _stream_reader
     cdef bint _negotiate_unix_fd
-
-    cpdef next_message(self)
+    cdef bint _read_complete
 
     cdef _next_message(self)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -125,6 +125,8 @@ cdef class Unmarshaller:
 
     cdef _next_message(self)
 
+    cdef _has_data_in_buffer(self)
+
     @cython.locals(
         msg=cython.bytes,
         recv=cython.tuple,

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -123,17 +123,23 @@ cdef class Unmarshaller:
     cpdef reset(self)
 
     @cython.locals(
-        msg=cython.bytes,
+        data=cython.bytes,
         recv=cython.tuple
     )
-    cdef bytes _read_sock(self, object length)
+    cdef _read_sock_with_fds(self, unsigned int pos)
 
     @cython.locals(
-        start_len=cython.ulong,
-        missing_bytes=cython.ulong,
+        data=cython.bytes,
+    )
+    cdef _read_sock_without_fds(self, unsigned int pos)
+
+    @cython.locals(
+        missing_bytes=cython.uint,
         data=cython.bytes
     )
-    cdef _read_to_pos(self, unsigned long pos)
+    cdef _read_stream(self, unsigned int pos)
+
+    cdef _read_to_pos(self, unsigned int pos)
 
     cpdef read_boolean(self, SignatureType type_)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -131,7 +131,7 @@ cdef class Unmarshaller:
         recv=cython.tuple,
         errno=cython.uint
     )
-    cdef _read_sock_with_fds(self, unsigned int pos)
+    cdef _read_sock_with_fds(self, unsigned int pos, unsigned int missing_bytes)
 
     @cython.locals(
         data=cython.bytes,

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -116,6 +116,7 @@ cdef class Unmarshaller:
     cdef object _int16_unpack
     cdef object _uint16_unpack
     cdef object _stream_reader
+    cdef object _negotiate_unix_fd
 
     cdef _reset(self)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -78,6 +78,7 @@ cdef unsigned int TOKEN_S_AS_INT
 cdef unsigned int TOKEN_G_AS_INT
 
 cdef object MARSHALL_STREAM_END_ERROR
+cdef object DEFAULT_BUFFER_SIZE
 
 cdef get_signature_tree
 
@@ -119,8 +120,6 @@ cdef class Unmarshaller:
     cdef object _negotiate_unix_fd
 
     cdef _reset(self)
-
-    cpdef reset(self)
 
     @cython.locals(
         data=cython.bytes,

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -80,8 +80,8 @@ cdef unsigned int TOKEN_G_AS_INT
 cdef object MARSHALL_STREAM_END_ERROR
 cdef object DEFAULT_BUFFER_SIZE
 
-cdef object EAGAIN
-cdef object EWOULDBLOCK
+cdef cython.uint EAGAIN
+cdef cython.uint EWOULDBLOCK
 
 cdef get_signature_tree
 
@@ -128,12 +128,14 @@ cdef class Unmarshaller:
 
     @cython.locals(
         data=cython.bytes,
-        recv=cython.tuple
+        recv=cython.tuple,
+        errno=cython.uint
     )
     cdef _read_sock_with_fds(self, unsigned int pos)
 
     @cython.locals(
         data=cython.bytes,
+        errno=cython.uint
     )
     cdef _read_sock_without_fds(self, unsigned int pos)
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -80,6 +80,9 @@ cdef unsigned int TOKEN_G_AS_INT
 cdef object MARSHALL_STREAM_END_ERROR
 cdef object DEFAULT_BUFFER_SIZE
 
+cdef object EAGAIN
+cdef object EWOULDBLOCK
+
 cdef get_signature_tree
 
 

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -119,6 +119,8 @@ cdef class Unmarshaller:
     cdef object _stream_reader
     cdef object _negotiate_unix_fd
 
+    cpdef next_message(self)
+
     cdef _next_message(self)
 
     @cython.locals(

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -271,7 +271,7 @@ class Unmarshaller:
 
     def _has_another_message_in_buffer(self) -> bool:
         """Check if there is another message in the buffer."""
-        _LOGGER.warning(
+        logging.error(
             "has_another_message_in_buffer: buf_len=%s message_size=%s",
             len(self._buf),
             HEADER_SIGNATURE_SIZE + self._msg_len,

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -289,10 +289,10 @@ class Unmarshaller:
                     raise MARSHALL_STREAM_END_ERROR
                 raise
             data = recv[0]
+            ancdata = recv[1]
             pprint.pprint(
                 ["_read_sock_with_fds - read", pos, len(self._buf), data, ancdata]
             )
-            ancdata = recv[1]
             if ancdata:
                 for level, type_, data in ancdata:
                     if not (level == SOL_SOCKET and type_ == SCM_RIGHTS):

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -241,7 +241,7 @@ class Unmarshaller:
         Call this before processing a new message.
         """
         self._unix_fds = []
-        del self._buf[: self._pos]
+        del self._buf[: HEADER_SIGNATURE_SIZE + self._msg_len]
         self._message = None
         self._pos = 0
         self._body_len = 0

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -178,7 +178,9 @@ except ImportError:
 class Unmarshaller:
     """Unmarshall messages from a stream.
 
-    When calling with sock, _next_message must be called before processing a new message.
+    When calling with sock and _negotiate_unix_fd False, the unmashaller must
+    be called continuously for each new message as it will buffer the data
+    until a complete message is available.
     """
 
     __slots__ = (

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -1,7 +1,6 @@
 import array
 import errno
 import io
-import logging
 import socket
 import sys
 from struct import Struct
@@ -12,8 +11,6 @@ from ..errors import InvalidMessageError
 from ..message import Message
 from ..signature import SignatureType, Variant, get_signature_tree
 from .constants import BIG_ENDIAN, LITTLE_ENDIAN, PROTOCOL_VERSION
-
-_LOGGER = logging.getLogger(__name__)
 
 MAX_UNIX_FDS = 16
 MAX_UNIX_FDS_SIZE = array.array("i").itemsize
@@ -271,11 +268,6 @@ class Unmarshaller:
 
     def _has_another_message_in_buffer(self) -> bool:
         """Check if there is another message in the buffer."""
-        logging.error(
-            "has_another_message_in_buffer: buf_len=%s message_size=%s",
-            len(self._buf),
-            HEADER_SIGNATURE_SIZE + self._msg_len,
-        )
         return len(self._buf) > HEADER_SIGNATURE_SIZE + self._msg_len
 
     def _read_sock_with_fds(self, pos: _int, missing_bytes: _int) -> None:

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -200,7 +200,7 @@ class Unmarshaller:
 
     def __init__(
         self,
-        stream: io.BufferedRWPair,
+        stream: Optional[io.BufferedRWPair] = None,
         sock: Optional[socket.socket] = None,
         negotiate_unix_fd: bool = True,
     ) -> None:
@@ -223,7 +223,7 @@ class Unmarshaller:
         self._uint16_unpack: Optional[Callable] = None
         self._stream_reader: Optional[Callable] = None
         self._negotiate_unix_fd = negotiate_unix_fd
-        if self._sock is None:
+        if stream:
             if isinstance(stream, io.BufferedRWPair) and hasattr(stream, "reader"):
                 self._stream_reader = stream.reader.read  # type: ignore[attr-defined]
             self._stream_reader = stream.read

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -288,10 +288,10 @@ class Unmarshaller:
                 if errno == EAGAIN or errno == EWOULDBLOCK:
                     raise MARSHALL_STREAM_END_ERROR
                 raise
-            data = recv[0]
+            msg = recv[0]
             ancdata = recv[1]
             pprint.pprint(
-                ["_read_sock_with_fds - read", pos, len(self._buf), data, ancdata]
+                ["_read_sock_with_fds - read", pos, len(self._buf), msg, ancdata]
             )
             if ancdata:
                 for level, type_, data in ancdata:
@@ -300,11 +300,11 @@ class Unmarshaller:
                     self._unix_fds.extend(
                         ARRAY("i", data[: len(data) - (len(data) % MAX_UNIX_FDS_SIZE)])
                     )
-            if data is None:
+            if msg is None:
                 raise MARSHALL_STREAM_END_ERROR
-            if data == b"":
+            if msg == b"":
                 raise EOFError()
-            self._buf += data
+            self._buf += msg
             if len(self._buf) >= pos:
                 return
 

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -342,11 +342,8 @@ class Unmarshaller:
                 )
                 return
 
-    def _read_stream(self, pos: _int) -> bytes:
+    def _read_stream(self, pos: _int, missing_bytes: _int) -> bytes:
         """Read from the stream."""
-        missing_bytes = pos - len(self._buf)
-        if missing_bytes <= 0:
-            return
         data = self._stream_reader(missing_bytes)  # type: ignore[misc]
         if data is None:
             raise MARSHALL_STREAM_END_ERROR
@@ -369,8 +366,11 @@ class Unmarshaller:
         :returns:
             None
         """
+        missing_bytes = pos - len(self._buf)
+        if missing_bytes <= 0:
+            return
         if self._sock is None:
-            self._read_stream(pos)
+            self._read_stream(pos, missing_bytes)
         elif self._negotiate_unix_fd:
             self._read_sock_with_fds(pos)
         else:

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -299,9 +299,12 @@ class Unmarshaller:
         """
         # This will raise BlockingIOError if there is no data to read
         # which we store in the MARSHALL_STREAM_END_ERROR object
+        import pprint
 
         while True:
+            pprint.pprint(["_read_sock_without_fds", pos, len(self._buf)])
             data = self._sock.recv(DEFAULT_BUFFER_SIZE)  # type: ignore[union-attr]
+            pprint.pprint(["_read_sock_without_fds", pos, len(self._buf), data])
             if data is None:
                 raise MARSHALL_STREAM_END_ERROR
             if data == b"":

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -313,16 +313,6 @@ class Unmarshaller:
         import pprint
 
         while True:
-            missing_bytes = pos - len(self._buf)
-            pprint.pprint(
-                [
-                    "_read_sock_without_fds",
-                    pos,
-                    "missing_bytes",
-                    missing_bytes,
-                    len(self._buf),
-                ]
-            )
             try:
                 data = self._sock.recv(DEFAULT_BUFFER_SIZE)  # type: ignore[union-attr]
             except OSError as e:
@@ -330,16 +320,12 @@ class Unmarshaller:
                 if errno == EAGAIN or errno == EWOULDBLOCK:
                     raise MARSHALL_STREAM_END_ERROR
                 raise
-            pprint.pprint(["_read_sock_without_fds", pos, len(self._buf), data])
             if data is None:
                 raise MARSHALL_STREAM_END_ERROR
             if data == b"":
                 raise EOFError()
             self._buf += data
             if len(self._buf) >= pos:
-                pprint.pprint(
-                    ["_read_sock_without_fds got enough", pos, len(self._buf)]
-                )
                 return
 
     def _read_stream(self, pos: _int, missing_bytes: _int) -> bytes:

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -266,7 +266,7 @@ class Unmarshaller:
         """Return the message that has been unmarshalled."""
         return self._message
 
-    def _has_another_message_in_buffer(self) -> None:
+    def _has_another_message_in_buffer(self) -> bool:
         """Check if there is another message in the buffer."""
         return len(self._buf) > HEADER_SIGNATURE_SIZE + self._msg_len
 

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -295,8 +295,6 @@ class Unmarshaller:
                 self._unix_fds.extend(
                     ARRAY("i", data[: len(data) - (len(data) % MAX_UNIX_FDS_SIZE)])
                 )
-        if msg is None:
-            raise MARSHALL_STREAM_END_ERROR
         if msg == b"":
             raise EOFError()
         self._buf += msg
@@ -319,8 +317,6 @@ class Unmarshaller:
                 if errno == EAGAIN or errno == EWOULDBLOCK:
                     raise MARSHALL_STREAM_END_ERROR
                 raise
-            if data is None:
-                raise MARSHALL_STREAM_END_ERROR
             if data == b"":
                 raise EOFError()
             self._buf += data

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -313,7 +313,16 @@ class Unmarshaller:
         import pprint
 
         while True:
-            pprint.pprint(["_read_sock_without_fds", pos, len(self._buf)])
+            missing_bytes = pos - len(self._buf)
+            pprint.pprint(
+                [
+                    "_read_sock_without_fds",
+                    pos,
+                    "missing_bytes",
+                    missing_bytes,
+                    len(self._buf),
+                ]
+            )
             try:
                 data = self._sock.recv(DEFAULT_BUFFER_SIZE)  # type: ignore[union-attr]
             except OSError as e:
@@ -328,6 +337,9 @@ class Unmarshaller:
                 raise EOFError()
             self._buf += data
             if len(self._buf) >= pos:
+                pprint.pprint(
+                    ["_read_sock_without_fds got enough", pos, len(self._buf)]
+                )
                 return
 
     def _read_stream(self, pos: _int) -> bytes:

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -173,7 +173,7 @@ except ImportError:
 class Unmarshaller:
     """Unmarshall messages from a stream.
 
-    When calling with sock, _reset must be called before processing a new message.
+    When calling with sock, _next_message must be called before processing a new message.
     """
 
     __slots__ = (
@@ -228,7 +228,7 @@ class Unmarshaller:
                 self._stream_reader = stream.reader.read  # type: ignore[attr-defined]
             self._stream_reader = stream.read
 
-    def _reset(self) -> None:
+    def _next_message(self) -> None:
         """Reset the unmarshaller to its initial state.
 
         Call this before processing a new message.

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -228,6 +228,13 @@ class Unmarshaller:
                 self._stream_reader = stream.reader.read  # type: ignore[attr-defined]
             self._stream_reader = stream.read
 
+    def next_message(self) -> None:
+        """Reset the unmarshaller to its initial state.
+
+        Call this before processing a new message.
+        """
+        self._next_message()
+
     def _next_message(self) -> None:
         """Reset the unmarshaller to its initial state.
 

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -288,7 +288,7 @@ class Unmarshaller:
         missing_bytes = pos - (start_len - self._pos)
         if self._sock is None:
             data = self._stream_reader(missing_bytes)  # type: ignore[misc]
-        elif self._receive_fds:
+        elif self._negotiate_unix_fd:
             data = self._read_sock(missing_bytes)
         else:
             data = self._sock.recv(missing_bytes)

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -222,13 +222,6 @@ class Unmarshaller:
                 self._stream_reader = stream.reader.read  # type: ignore[attr-defined]
             self._stream_reader = stream.read
 
-    def reset(self) -> None:
-        """Reset the unmarshaller to its initial state.
-
-        Call this before processing a new message.
-        """
-        self._reset()
-
     def _reset(self) -> None:
         """Reset the unmarshaller to its initial state.
 
@@ -673,7 +666,9 @@ class Unmarshaller:
             self._read_body()
         except MARSHALL_STREAM_END_ERROR:
             return None
-        return self._message
+        message = self._message
+        self._reset()
+        return message
 
     _complex_parsers_unpack: Dict[
         str, Callable[["Unmarshaller", SignatureType], Any]

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -264,6 +264,10 @@ class Unmarshaller:
         """Return the message that has been unmarshalled."""
         return self._message
 
+    def _has_data_in_buffer(self) -> None:
+        """Check if there is data in the buffer."""
+        return len(self._buf) > 0
+
     def _read_sock_with_fds(self, pos: _int, missing_bytes: _int) -> None:
         """reads from the socket, storing any fds sent and handling errors
         from the read itself.

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -1,6 +1,7 @@
 import array
 import errno
 import io
+import logging
 import socket
 import sys
 from struct import Struct
@@ -11,6 +12,8 @@ from ..errors import InvalidMessageError
 from ..message import Message
 from ..signature import SignatureType, Variant, get_signature_tree
 from .constants import BIG_ENDIAN, LITTLE_ENDIAN, PROTOCOL_VERSION
+
+_LOGGER = logging.getLogger(__name__)
 
 MAX_UNIX_FDS = 16
 MAX_UNIX_FDS_SIZE = array.array("i").itemsize
@@ -268,6 +271,11 @@ class Unmarshaller:
 
     def _has_another_message_in_buffer(self) -> bool:
         """Check if there is another message in the buffer."""
+        _LOGGER.warning(
+            "has_another_message_in_buffer: buf_len=%s message_size=%s",
+            len(self._buf),
+            HEADER_SIGNATURE_SIZE + self._msg_len,
+        )
         return len(self._buf) > HEADER_SIGNATURE_SIZE + self._msg_len
 
     def _read_sock_with_fds(self, pos: _int, missing_bytes: _int) -> None:

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -241,7 +241,11 @@ class Unmarshaller:
         Call this before processing a new message.
         """
         self._unix_fds = []
-        del self._buf[: HEADER_SIGNATURE_SIZE + self._msg_len]
+        to_clear = HEADER_SIGNATURE_SIZE + self._msg_len
+        if len(self._buf) == to_clear:
+            self._buf = bytearray()
+        else:
+            del self._buf[:to_clear]
         self._message = None
         self._pos = 0
         self._body_len = 0

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -171,6 +171,10 @@ except ImportError:
 #
 #
 class Unmarshaller:
+    """Unmarshall messages from a stream.
+
+    When calling with sock, _reset must be called before processing a new message.
+    """
 
     __slots__ = (
         "_unix_fds",

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -266,9 +266,9 @@ class Unmarshaller:
         """Return the message that has been unmarshalled."""
         return self._message
 
-    def _has_data_in_buffer(self) -> None:
-        """Check if there is data in the buffer."""
-        return len(self._buf) > 0
+    def _has_another_message_in_buffer(self) -> None:
+        """Check if there is another message in the buffer."""
+        return len(self._buf) > HEADER_SIGNATURE_SIZE + self._msg_len
 
     def _read_sock_with_fds(self, pos: _int, missing_bytes: _int) -> None:
         """reads from the socket, storing any fds sent and handling errors

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -277,7 +277,10 @@ class Unmarshaller:
         """
         # This will raise BlockingIOError if there is no data to read
         # which we store in the MARSHALL_STREAM_END_ERROR object
+        import pprint
+
         while True:
+            pprint.pprint(["_read_sock_with_fds", pos, len(self._buf)])
             try:
                 recv = self._sock.recvmsg(DEFAULT_BUFFER_SIZE, UNIX_FDS_CMSG_LENGTH)  # type: ignore[union-attr]
             except OSError as e:
@@ -286,6 +289,9 @@ class Unmarshaller:
                     raise MARSHALL_STREAM_END_ERROR
                 raise
             data = recv[0]
+            pprint.pprint(
+                ["_read_sock_with_fds - read", pos, len(self._buf), data, ancdata]
+            )
             ancdata = recv[1]
             if ancdata:
                 for level, type_, data in ancdata:
@@ -310,8 +316,6 @@ class Unmarshaller:
         """
         # This will raise BlockingIOError if there is no data to read
         # which we store in the MARSHALL_STREAM_END_ERROR object
-        import pprint
-
         while True:
             try:
                 data = self._sock.recv(DEFAULT_BUFFER_SIZE)  # type: ignore[union-attr]

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -235,7 +235,7 @@ class Unmarshaller:
         Call this before processing a new message.
         """
         self._unix_fds = []
-        self._buf.clear()
+        del self._buf[: self._pos]
         self._message = None
         self._pos = 0
         self._body_len = 0

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -281,7 +281,8 @@ class Unmarshaller:
             try:
                 recv = self._sock.recvmsg(DEFAULT_BUFFER_SIZE, UNIX_FDS_CMSG_LENGTH)  # type: ignore[union-attr]
             except OSError as e:
-                if e.errno == EAGAIN or e.errno == EWOULDBLOCK:
+                errno = e.errno
+                if errno == EAGAIN or errno == EWOULDBLOCK:
                     raise MARSHALL_STREAM_END_ERROR
                 raise
             data = recv[0]
@@ -316,7 +317,8 @@ class Unmarshaller:
             try:
                 data = self._sock.recv(DEFAULT_BUFFER_SIZE)  # type: ignore[union-attr]
             except OSError as e:
-                if e.errno == EAGAIN or e.errno == EWOULDBLOCK:
+                errno = e.errno
+                if errno == EAGAIN or errno == EWOULDBLOCK:
                     raise MARSHALL_STREAM_END_ERROR
                 raise
             pprint.pprint(["_read_sock_without_fds", pos, len(self._buf), data])

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -202,7 +202,7 @@ class MessageBus(BaseMessageBus):
             self._fd,
             build_message_reader(
                 self._stream,
-                self._sock if self._negotiate_unix_fd else None,
+                self._sock,
                 self._process_message,
                 self._finalize,
             ),

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -201,7 +201,6 @@ class MessageBus(BaseMessageBus):
         self._loop.add_reader(
             self._fd,
             build_message_reader(
-                self._stream,
                 self._sock,
                 self._process_message,
                 self._finalize,

--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -205,6 +205,7 @@ class MessageBus(BaseMessageBus):
                 self._sock,
                 self._process_message,
                 self._finalize,
+                self._negotiate_unix_fd,
             ),
         )
 

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -30,6 +30,8 @@ def build_message_reader(
                     logging.error(
                         f"got unexpected error processing a message: {e}.\n{traceback.format_exc()}"
                     )
+                if not negotiate_unix_fd and not unmarshaller._has_data_in_buffer():
+                    return
         except Exception as e:
             finalize(e)
 

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -1,6 +1,5 @@
 import logging
 import socket
-import traceback
 from typing import Callable, Optional
 
 from .._private.unmarshaller import Unmarshaller
@@ -16,10 +15,6 @@ def build_message_reader(
     """Build a callable that reads messages from the unmarshaller and passes them to the process function."""
     unmarshaller = Unmarshaller(None, sock, negotiate_unix_fd)
 
-    logging.error(
-        "build_message_reader: sock=%s negotiate_unix_fd=%s", sock, negotiate_unix_fd
-    )
-
     def _message_reader() -> None:
         """Reads messages from the unmarshaller and passes them to the process function."""
         try:
@@ -31,7 +26,7 @@ def build_message_reader(
                     process(message)
                 except Exception as e:
                     logging.error(
-                        f"got unexpected error processing a message: {e}.\n{traceback.format_exc()}"
+                        "Unexpected error processing message: %s", exc_info=True
                     )
                 # If we are not negotiating unix fds, we can stop reading as soon as we have
                 # the buffer is empty as asyncio will call us again when there is more data.

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -31,6 +31,7 @@ def build_message_reader(
                     logging.error(
                         f"got unexpected error processing a message: {e}.\n{traceback.format_exc()}"
                     )
+                unmarshaller._reset()
         except Exception as e:
             finalize(e)
 

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -31,7 +31,7 @@ def build_message_reader(
                     logging.error(
                         f"got unexpected error processing a message: {e}.\n{traceback.format_exc()}"
                     )
-                unmarshaller._reset()
+                unmarshaller._next_message()
         except Exception as e:
             finalize(e)
 

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -30,6 +30,8 @@ def build_message_reader(
                     logging.error(
                         f"got unexpected error processing a message: {e}.\n{traceback.format_exc()}"
                     )
+                # If we are not negotiating unix fds, we can stop reading as soon as we have
+                # the buffer is empty as asyncio will call us again when there is more data.
                 if not negotiate_unix_fd and not unmarshaller._has_data_in_buffer():
                     return
         except Exception as e:

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -13,9 +13,10 @@ def build_message_reader(
     sock: Optional[socket.socket],
     process: Callable[[Message], None],
     finalize: Callable[[Optional[Exception]], None],
+    negotiate_unix_fd: bool,
 ) -> None:
     """Build a callable that reads messages from the unmarshaller and passes them to the process function."""
-    unmarshaller = Unmarshaller(stream, sock)
+    unmarshaller = Unmarshaller(stream, sock, negotiate_unix_fd)
 
     def _message_reader() -> None:
         """Reads messages from the unmarshaller and passes them to the process function."""

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -32,7 +32,10 @@ def build_message_reader(
                     )
                 # If we are not negotiating unix fds, we can stop reading as soon as we have
                 # the buffer is empty as asyncio will call us again when there is more data.
-                if not negotiate_unix_fd and not unmarshaller._has_data_in_buffer():
+                if (
+                    not negotiate_unix_fd
+                    and not unmarshaller._has_another_message_in_buffer()
+                ):
                     return
         except Exception as e:
             finalize(e)

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -1,4 +1,3 @@
-import io
 import logging
 import socket
 import traceback
@@ -6,6 +5,8 @@ from typing import Callable, Optional
 
 from .._private.unmarshaller import Unmarshaller
 from ..message import Message
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def build_message_reader(
@@ -16,6 +17,10 @@ def build_message_reader(
 ) -> None:
     """Build a callable that reads messages from the unmarshaller and passes them to the process function."""
     unmarshaller = Unmarshaller(None, sock, negotiate_unix_fd)
+
+    _LOGGER.warning(
+        "build_message_reader: sock=%s negotiate_unix_fd=%s", sock, negotiate_unix_fd
+    )
 
     def _message_reader() -> None:
         """Reads messages from the unmarshaller and passes them to the process function."""

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -9,14 +9,13 @@ from ..message import Message
 
 
 def build_message_reader(
-    stream: io.BufferedRWPair,
     sock: Optional[socket.socket],
     process: Callable[[Message], None],
     finalize: Callable[[Optional[Exception]], None],
     negotiate_unix_fd: bool,
 ) -> None:
     """Build a callable that reads messages from the unmarshaller and passes them to the process function."""
-    unmarshaller = Unmarshaller(stream, sock, negotiate_unix_fd)
+    unmarshaller = Unmarshaller(None, sock, negotiate_unix_fd)
 
     def _message_reader() -> None:
         """Reads messages from the unmarshaller and passes them to the process function."""

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -30,7 +30,6 @@ def build_message_reader(
                     logging.error(
                         f"got unexpected error processing a message: {e}.\n{traceback.format_exc()}"
                     )
-                unmarshaller._next_message()
         except Exception as e:
             finalize(e)
 

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -6,8 +6,6 @@ from typing import Callable, Optional
 from .._private.unmarshaller import Unmarshaller
 from ..message import Message
 
-_LOGGER = logging.getLogger(__name__)
-
 
 def build_message_reader(
     sock: Optional[socket.socket],
@@ -18,7 +16,7 @@ def build_message_reader(
     """Build a callable that reads messages from the unmarshaller and passes them to the process function."""
     unmarshaller = Unmarshaller(None, sock, negotiate_unix_fd)
 
-    _LOGGER.warning(
+    logging.error(
         "build_message_reader: sock=%s negotiate_unix_fd=%s", sock, negotiate_unix_fd
     )
 

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -31,7 +31,6 @@ def build_message_reader(
                     logging.error(
                         f"got unexpected error processing a message: {e}.\n{traceback.format_exc()}"
                     )
-                unmarshaller._reset()
         except Exception as e:
             finalize(e)
 

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -457,21 +457,21 @@ def test_unmarshall_multiple_messages():
     unpacked = unpack_variants(message.body)
     assert unpacked == ["org.bluez.Device1", {"RSSI": -76}, []]
 
-    unmarshaller.reset()
+    unmarshaller.next_message()
     assert unmarshaller.unmarshall()
     message = unmarshaller.message
     assert message is not None
     unpacked = unpack_variants(message.body)
     assert unpacked == ["org.bluez.Device1", {"RSSI": -80}, []]
 
-    unmarshaller.reset()
+    unmarshaller.next_message()
     assert unmarshaller.unmarshall()
     message = unmarshaller.message
     assert message is not None
     unpacked = unpack_variants(message.body)
     assert unpacked == ["org.bluez.Device1", {"RSSI": -94}, []]
 
-    unmarshaller.reset()
+    unmarshaller.next_message()
     with pytest.raises(EOFError):
         unmarshaller.unmarshall()
 

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -457,21 +457,18 @@ def test_unmarshall_multiple_messages():
     unpacked = unpack_variants(message.body)
     assert unpacked == ["org.bluez.Device1", {"RSSI": -76}, []]
 
-    unmarshaller.next_message()
     assert unmarshaller.unmarshall()
     message = unmarshaller.message
     assert message is not None
     unpacked = unpack_variants(message.body)
     assert unpacked == ["org.bluez.Device1", {"RSSI": -80}, []]
 
-    unmarshaller.next_message()
     assert unmarshaller.unmarshall()
     message = unmarshaller.message
     assert message is not None
     unpacked = unpack_variants(message.body)
     assert unpacked == ["org.bluez.Device1", {"RSSI": -94}, []]
 
-    unmarshaller.next_message()
     with pytest.raises(EOFError):
         unmarshaller.unmarshall()
 


### PR DESCRIPTION
We already buffer in the unmarshaller so we shouldn't do it twice if we can avoid it when `negotiate_unix_fd` is `False`

`recvmsg` for the `negotiate_unix_fd` path did not check for `EAGAIN` or `EWOULDBLOCK` which could result in unexplained failures

This is ~33.17% speed up