### PR TITLE
fix: spelling of `dbus_fast.auth.AuthAnnonymous` to `dbus_fast.auth.AuthAnonymous`

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -6,4 +6,4 @@ Classes for the DBus `authentication protocol <https://dbus.freedesktop.org/doc/
 .. autoclass:: dbus_fast.auth.Authenticator
 
 .. autoclass:: dbus_fast.auth.AuthExternal
-.. autoclass:: dbus_fast.auth.AuthAnnonymous
+.. autoclass:: dbus_fast.auth.AuthAnonymous

--- a/src/dbus_fast/auth.py
+++ b/src/dbus_fast/auth.py
@@ -99,8 +99,8 @@ class AuthExternal(Authenticator):
         raise AuthError(f"authentication failed: {response.value}: {args}")
 
 
-class AuthAnnonymous(Authenticator):
-    """An authenticator class for the annonymous auth protocol for use with the
+class AuthAnonymous(Authenticator):
+    """An authenticator class for the anonymous auth protocol for use with the
     :class:`MessageBus <dbus_fast.message_bus.BaseMessageBus>`.
 
     :sealso: https://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol
@@ -109,7 +109,7 @@ class AuthAnnonymous(Authenticator):
     def _authentication_start(self, negotiate_unix_fd: bool = False) -> str:
         if negotiate_unix_fd:
             raise AuthError(
-                "annonymous authentication does not support negotiating unix fds right now"
+                "anonymous authentication does not support negotiating unix fds right now"
             )
 
         return "AUTH ANONYMOUS"
@@ -121,3 +121,7 @@ class AuthAnnonymous(Authenticator):
             raise AuthError(f"authentication failed: {response.value}: {args}")
 
         return "BEGIN"
+
+
+# The following line provides backwards compatibility, remove at some point? --jrd
+AuthAnnonymous = AuthAnonymous

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,9 +3,13 @@ import os
 
 import pytest
 
-from dbus_fast.auth import UID_NOT_SPECIFIED, AuthExternal
+from dbus_fast.auth import (
+    UID_NOT_SPECIFIED,
+    AuthAnnonymous,
+    AuthAnonymous,
+    AuthExternal,
+)
 from dbus_fast.errors import AuthError
-from dbus_fast.auth import AuthAnnonymous, AuthAnonymous
 
 
 def test_annonymous_backcompat():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,6 +5,12 @@ import pytest
 
 from dbus_fast.auth import UID_NOT_SPECIFIED, AuthExternal
 from dbus_fast.errors import AuthError
+from dbus_fast.auth import AuthAnnonymous, AuthAnonymous
+
+
+def test_annonymous_backcompat():
+    auth = AuthAnnonymous()
+    assert isinstance(auth, AuthAnonymous)
 
 
 def test_uid_is_set():


### PR DESCRIPTION
Pretty straightforward.  Don't think very many people use the ANONYMOUS auth, but included a line to keep backwards compatibility to not break anybody using the misspelled version.