### PR TITLE
fix: revert changes to _expects_reply from speed up to processing blu…

### DIFF
--- a/src/dbus_fast/message_bus.pxd
+++ b/src/dbus_fast/message_bus.pxd
@@ -10,7 +10,7 @@ cdef object MessageFlag
 
 cdef object MESSAGE_TYPE_CALL
 cdef object MESSAGE_TYPE_SIGNAL
-cdef object NO_REPLY_EXPECTED
+cdef object NO_REPLY_EXPECTED_VALUE
 cdef object BLOCK_UNEXPECTED_REPLY
 cdef object assert_object_path_valid
 cdef object assert_bus_name_valid

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -27,7 +27,7 @@ from .validators import assert_bus_name_valid, assert_object_path_valid
 
 MESSAGE_TYPE_CALL = MessageType.METHOD_CALL
 MESSAGE_TYPE_SIGNAL = MessageType.SIGNAL
-NO_REPLY_EXPECTED = MessageFlag.NO_REPLY_EXPECTED
+NO_REPLY_EXPECTED_VALUE = MessageFlag.NO_REPLY_EXPECTED.value
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -36,7 +36,7 @@ _Message = Message
 
 def _expects_reply(msg: _Message) -> bool:
     """Whether a message expects a reply."""
-    return not (msg.flags & NO_REPLY_EXPECTED)
+    return not (msg.flags.value & NO_REPLY_EXPECTED_VALUE)
 
 
 def _block_unexpected_reply(reply: _Message) -> None:


### PR DESCRIPTION
…ez passive data

This turned out to be slower in cython, but faster in pure python and since we prefer cython it should be reverted