### PR TITLE
fix: avoid checking if a message expects a reply twice

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -923,7 +923,7 @@ class BaseMessageBus:
             msg: Message, send_reply: Callable[[Message], None]
         ) -> None:
             result = method_fn(interface, *msg_body_to_args(msg))
-            if not _expects_reply(msg):
+            if send_reply is BLOCK_UNEXPECTED_REPLY or not _expects_reply(msg):
                 return
             body, fds = fn_result_to_body(
                 result,


### PR DESCRIPTION
We can do an `is` check here since we know it will be the dummy object is no reply is expected to speed up the check in the event no reply is expected.

The performance of the reply expected case will be a tiny bit slower but those messages are far less frequent