### PR TITLE
fix: avoid cythonizing SendReply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,5 +96,5 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ['setuptools>=65.4.1', 'wheel', 'Cython<3.0.0', "poetry-core>=1.0.0"]
+requires = ['setuptools>=65.4.1', 'wheel', 'Cython', "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,5 +96,5 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ['setuptools>=65.4.1', 'wheel', 'Cython', "poetry-core>=1.0.0"]
+requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3.0.0', "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,5 +96,5 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3.0.0', "poetry-core>=1.0.0"]
+requires = ['setuptools>=65.4.1', 'wheel', 'Cython<3.0.0', "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/dbus_fast/message_bus.pxd
+++ b/src/dbus_fast/message_bus.pxd
@@ -18,11 +18,6 @@ cdef object assert_bus_name_valid
 cdef _expects_reply(Message msg)
 
 
-cdef class SendReply:
-
-    cdef object _bus
-    cdef object _msg
-
 cdef class BaseMessageBus:
 
     cdef public object unique_name

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -105,6 +105,8 @@ class SendReply:
     ) -> bool:
         import pprint
 
+
+
         pprint.pprint(["__exit__", exc_type, exc_value, tb])
         return self._exit(exc_type, exc_value, tb)
 

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -1,11 +1,8 @@
 import inspect
 import logging
-import pprint
 import socket
-import sys
 import traceback
 import xml.etree.ElementTree as ET
-from types import TracebackType
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from . import introspection as intr
@@ -23,6 +20,7 @@ from .constants import (
 from .errors import DBusError, InvalidAddressError
 from .message import Message
 from .proxy_object import BaseProxyObject
+from .send_reply import SendReply
 from .service import ServiceInterface, _Method
 from .signature import Variant
 from .validators import assert_bus_name_valid, assert_object_path_valid
@@ -57,57 +55,6 @@ def _block_unexpected_reply(reply: _Message) -> None:
 
 
 BLOCK_UNEXPECTED_REPLY = _block_unexpected_reply
-
-
-class SendReply:
-    """A context manager to send a reply to a message."""
-
-    __slots__ = ("_bus", "_msg")
-
-    def __init__(self, bus: "BaseMessageBus", msg: Message) -> None:
-        """Create a new reply context manager."""
-        self._bus = bus
-        self._msg = msg
-
-    def __enter__(self):
-        return self
-
-    def __call__(self, reply: Message) -> None:
-        self._bus.send(reply)
-
-    def _exit(
-        self,
-        exc_type: Optional[Type[Exception]],
-        exc_value: Optional[Exception],
-        tb: Optional[TracebackType],
-    ) -> bool:
-        if exc_value:
-            sys.stderr.write(pprint.pformat(["_exit", exc_type, exc_value, tb]) + "\n")
-            if isinstance(exc_value, DBusError):
-                self(exc_value._as_message(self._msg))
-            else:
-                self(
-                    Message.new_error(
-                        self._msg,
-                        ErrorType.SERVICE_ERROR,
-                        f"The service interface raised an error: {exc_value}.\n{traceback.format_tb(tb)}",
-                    )
-                )
-            return True
-
-        return False
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[Exception]],
-        exc_value: Optional[Exception],
-        tb: Optional[TracebackType],
-    ) -> bool:
-        sys.stderr.write(pprint.pformat(["__exit__", exc_type, exc_value, tb]) + "\n")
-        return self._exit(exc_type, exc_value, tb)
-
-    def send_error(self, exc: Exception) -> None:
-        self._exit(exc.__class__, exc, exc.__traceback__)
 
 
 class BaseMessageBus:

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -80,6 +80,9 @@ class SendReply:
         tb: Optional[TracebackType],
     ) -> bool:
         if exc_value:
+            import pprint
+
+            pprint.pprint(["_exit", exc_type, exc_value, tb])
             if isinstance(exc_value, DBusError):
                 self(exc_value._as_message(self._msg))
             else:
@@ -100,6 +103,9 @@ class SendReply:
         exc_value: Optional[Exception],
         tb: Optional[TracebackType],
     ) -> bool:
+        import pprint
+
+        pprint.pprint(["__exit__", exc_type, exc_value, tb])
         return self._exit(exc_type, exc_value, tb)
 
     def send_error(self, exc: Exception) -> None:

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -1,6 +1,8 @@
 import inspect
 import logging
+import pprint
 import socket
+import sys
 import traceback
 import xml.etree.ElementTree as ET
 from types import TracebackType
@@ -80,9 +82,7 @@ class SendReply:
         tb: Optional[TracebackType],
     ) -> bool:
         if exc_value:
-            import pprint
-
-            pprint.pprint(["_exit", exc_type, exc_value, tb])
+            sys.stderr.write(pprint.pformat(["_exit", exc_type, exc_value, tb]) + "\n")
             if isinstance(exc_value, DBusError):
                 self(exc_value._as_message(self._msg))
             else:
@@ -103,11 +103,7 @@ class SendReply:
         exc_value: Optional[Exception],
         tb: Optional[TracebackType],
     ) -> bool:
-        import pprint
-
-
-
-        pprint.pprint(["__exit__", exc_type, exc_value, tb])
+        sys.stderr.write(pprint.pformat(["__exit__", exc_type, exc_value, tb]) + "\n")
         return self._exit(exc_type, exc_value, tb)
 
     def send_error(self, exc: Exception) -> None:

--- a/src/dbus_fast/send_reply.py
+++ b/src/dbus_fast/send_reply.py
@@ -1,0 +1,59 @@
+import traceback
+from types import TracebackType
+from typing import TYPE_CHECKING, Optional, Type
+
+from .constants import ErrorType
+from .errors import DBusError
+from .message import Message
+
+if TYPE_CHECKING:
+    from .message_bus import BaseMessageBus
+
+
+class SendReply:
+    """A context manager to send a reply to a message."""
+
+    __slots__ = ("_bus", "_msg")
+
+    def __init__(self, bus: "BaseMessageBus", msg: Message) -> None:
+        """Create a new reply context manager."""
+        self._bus = bus
+        self._msg = msg
+
+    def __enter__(self):
+        return self
+
+    def __call__(self, reply: Message) -> None:
+        self._bus.send(reply)
+
+    def _exit(
+        self,
+        exc_type: Optional[Type[Exception]],
+        exc_value: Optional[Exception],
+        tb: Optional[TracebackType],
+    ) -> bool:
+        if exc_value:
+            if isinstance(exc_value, DBusError):
+                self(exc_value._as_message(self._msg))
+            else:
+                self(
+                    Message.new_error(
+                        self._msg,
+                        ErrorType.SERVICE_ERROR,
+                        f"The service interface raised an error: {exc_value}.\n{traceback.format_tb(tb)}",
+                    )
+                )
+            return True
+
+        return False
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[Exception]],
+        exc_value: Optional[Exception],
+        tb: Optional[TracebackType],
+    ) -> bool:
+        return self._exit(exc_type, exc_value, tb)
+
+    def send_error(self, exc: Exception) -> None:
+        self._exit(exc.__class__, exc, exc.__traceback__)

--- a/tests/service/test_standard_interfaces.py
+++ b/tests/service/test_standard_interfaces.py
@@ -240,7 +240,6 @@ async def test_standard_interface_properties():
         "org.freedesktop.DBus.Peer",
         "org.freedesktop.DBus.ObjectManager",
     ]:
-
         result = await bus2.call(
             Message(
                 destination=bus1.unique_name,

--- a/tests/test_address_parser.py
+++ b/tests/test_address_parser.py
@@ -2,7 +2,6 @@ from dbus_fast._private.address import parse_address
 
 
 def test_valid_addresses():
-
     valid_addresses = {
         "unix:path=/run/user/1000/bus": [("unix", {"path": "/run/user/1000/bus"})],
         "unix:abstract=/tmp/dbus-ft9sODWpZk,guid=a7b1d5912379c2d471165e9b5cb74a03": [

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -104,7 +104,6 @@ def test_unmarshalling_with_table(unmarshall_table):
     from dbus_fast._private import unmarshaller
 
     for item in unmarshall_table:
-
         stream = io.BytesIO(bytes.fromhex(item["data"]))
         unmarshaller = Unmarshaller(stream)
         try:
@@ -486,7 +485,6 @@ def tests_fallback_no_cython():
 
 
 def test_unmarshall_large_message():
-
     stream = io.BytesIO(bytes.fromhex(get_managed_objects_msg))
     unmarshaller = Unmarshaller(stream)
     unmarshaller.unmarshall()

--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -1,15 +1,12 @@
 import os
-import traceback
-from types import TracebackType
-from typing import Any, Callable, Dict, List, Optional, Type, Union
-from unittest.mock import Mock
 
 import pytest
 
 from dbus_fast.constants import ErrorType, MessageType
 from dbus_fast.errors import DBusError
 from dbus_fast.message import Message
-from dbus_fast.message_bus import BaseMessageBus, SendReply
+from dbus_fast.message_bus import BaseMessageBus
+from dbus_fast.send_reply import SendReply
 
 
 @pytest.fixture(autouse=True)
@@ -44,7 +41,7 @@ def test_send_reply_exception() -> None:
     )
     send_reply = SendReply(mock_message_bus, mock_message)
 
-    with send_reply as reply:
+    with send_reply:
         raise DBusError(ErrorType.DISCONNECTED, "Disconnected", None)
 
     assert len(messages) == 1


### PR DESCRIPTION
This is a workaround since context managers currently have an issue with Cython 3

fixes #229
