### PR TITLE
feat!: don't import backends by default

### DIFF
--- a/src/dbus_fast/__init__.py
+++ b/src/dbus_fast/__init__.py
@@ -1,4 +1,4 @@
-from . import aio, glib, introspection, message_bus, proxy_object, service
+from . import introspection, message_bus, proxy_object, service
 from .constants import (
     ArgDirection,
     BusType,
@@ -40,8 +40,6 @@ from .validators import (
 )
 
 __all__ = [
-    "aio",
-    "glib",
     "introspection",
     "message_bus",
     "proxy_object",


### PR DESCRIPTION
Since the top-level `__init__.py` is always imported when any subpackage is imported, this caused both backends (glib and aio) to always be imported. This is not desirable, since it means that the glib backend will always be imported, even if the user only wants to use the aio. This wastes resources and in some cases can even cause a crash.

Fixes: https://github.com/Bluetooth-Devices/dbus-fast/issues/242