### PR TITLE
feat: speed up unmarshalling by skipping unused unix_fds header

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -23,6 +23,7 @@ cdef unsigned int LITTLE_ENDIAN
 cdef unsigned int BIG_ENDIAN
 cdef unsigned int PROTOCOL_VERSION
 cdef unsigned int HEADER_UNIX_FDS_IDX
+cdef cython.list HEADER_IDX_TO_ARG_NAME
 
 cdef str UINT32_CAST
 cdef str INT16_CAST

--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -22,6 +22,7 @@ cdef unsigned int HEADER_SIGNATURE_SIZE
 cdef unsigned int LITTLE_ENDIAN
 cdef unsigned int BIG_ENDIAN
 cdef unsigned int PROTOCOL_VERSION
+cdef unsigned int HEADER_UNIX_FDS_IDX
 
 cdef str UINT32_CAST
 cdef str INT16_CAST

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -108,19 +108,19 @@ SCM_RIGHTS = socket.SCM_RIGHTS
 EAGAIN = errno.EAGAIN
 EWOULDBLOCK = errno.EWOULDBLOCK
 
-HEADER_UNIX_FDS_IDX = 9
-
-HEADER_MESSAGE_ARG_NAME = {
-    1: "path",
-    2: "interface",
-    3: "member",
-    4: "error_name",
-    5: "reply_serial",
-    6: "destination",
-    7: "sender",
-    8: "signature",
-    HEADER_UNIX_FDS_IDX: "unix_fds",
-}
+HEADER_IDX_TO_ARG_NAME = [
+    "",
+    "path",
+    "interface",
+    "member",
+    "error_name",
+    "reply_serial",
+    "destination",
+    "sender",
+    "signature",
+    "unix_fds",
+]
+HEADER_UNIX_FDS_IDX = HEADER_IDX_TO_ARG_NAME.index("unix_fds")
 
 _SignatureType = SignatureType
 _int = int
@@ -586,7 +586,7 @@ class Unmarshaller:
                 continue
             token_as_int = buf[o]
             # Now that we have the token we can read the variant value
-            key = HEADER_MESSAGE_ARG_NAME[field_0]
+            key = HEADER_IDX_TO_ARG_NAME[field_0]
             # Strings and signatures are the most common types
             # so we inline them for performance
             if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -108,6 +108,7 @@ SCM_RIGHTS = socket.SCM_RIGHTS
 EAGAIN = errno.EAGAIN
 EWOULDBLOCK = errno.EWOULDBLOCK
 
+HEADER_UNIX_FDS_IDX = 9
 
 HEADER_MESSAGE_ARG_NAME = {
     1: "path",
@@ -118,7 +119,7 @@ HEADER_MESSAGE_ARG_NAME = {
     6: "destination",
     7: "sender",
     8: "signature",
-    9: "unix_fds",
+    HEADER_UNIX_FDS_IDX: "unix_fds",
 }
 
 _SignatureType = SignatureType
@@ -581,6 +582,8 @@ class Unmarshaller:
             signature_len = buf[self._pos]  # byte
             o = self._pos + 1
             self._pos += signature_len + 2  # one for the byte, one for the '\0'
+            if field_0 == HEADER_UNIX_FDS_IDX:  # defined by self._unix_fds
+                continue
             token_as_int = buf[o]
             # Now that we have the token we can read the variant value
             key = HEADER_MESSAGE_ARG_NAME[field_0]
@@ -661,7 +664,6 @@ class Unmarshaller:
         self._pos = HEADER_ARRAY_OF_STRUCT_SIGNATURE_POSITION
         header_fields = self._header_fields(self._header_len)
         self._pos += -self._pos & 7  # align 8
-        header_fields.pop("unix_fds", None)  # defined by self._unix_fds
         signature = header_fields.pop("signature", "")
         if not self._body_len:
             tree = SIGNATURE_TREE_EMPTY


### PR DESCRIPTION
We would always remove it so we should skip it instead