### PR TITLE
feat: add cython typing for ServiceInterface.name

### DIFF
--- a/src/dbus_fast/service.pxd
+++ b/src/dbus_fast/service.pxd
@@ -18,7 +18,7 @@ cdef class _Method:
 
 cdef class ServiceInterface:
 
-    cdef public object name
+    cdef public str name
     cdef list __methods
     cdef list __properties
     cdef list __signals

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -343,7 +343,7 @@ class ServiceInterface:
     :vartype name: str
     """
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         # TODO cannot be overridden by a dbus member
         self.name = name
         self.__methods: List[_Method] = []


### PR DESCRIPTION
We compare this a lot so we want to force __Pyx_PyUnicode_Equals