### PR TITLE
feat: make ErrorType enums compare as strings

### DIFF
--- a/src/dbus_fast/constants.py
+++ b/src/dbus_fast/constants.py
@@ -91,7 +91,7 @@ class ArgDirection(Enum):
     OUT = "out"
 
 
-class ErrorType(Enum):
+class ErrorType(str, Enum):
     """An enum for the type of an error for a message reply.
 
     :seealso: http://man7.org/linux/man-pages/man3/sd-bus-errors.3.html

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,6 +1,12 @@
-from dbus_fast.constants import MESSAGE_FLAG_MAP, MessageFlag
+from dbus_fast.constants import MESSAGE_FLAG_MAP, ErrorType, MessageFlag
+from dbus_fast.errors import DBusError
 
 
 def test_message_flag_map():
     assert 0 in MESSAGE_FLAG_MAP
     assert MessageFlag.NONE in MESSAGE_FLAG_MAP
+
+
+def test_error_type():
+    err = DBusError(ErrorType.FAILED, "")
+    assert ErrorType.FAILED == err.type


### PR DESCRIPTION
The DBusError exception stores the error type as string. This makes the exception not directly compare to the ErrorType members (for example DBusError(ErrorType.FAILED, "").type != ErrorType.FAILED). This makes ErrorType also a string to make this comparision work.