### PR TITLE
fix: clear exception flag on disconnect future if its also sent to handlers

### DIFF
--- a/tests/test_aio_low_level.py
+++ b/tests/test_aio_low_level.py
@@ -45,6 +45,26 @@ async def test_standard_interfaces():
 
 
 @pytest.mark.asyncio
+async def test_error_handling():
+    bus = await MessageBus().connect()
+    msg = Message(
+        destination="org.freedesktop.DBus",
+        path="/org/freedesktop/DBus",
+        interface="org.freedesktop.DBus",
+        member="InvalidMember",
+        serial=bus.next_serial(),
+    )
+    reply = await bus.call(msg)
+
+    assert reply.message_type == MessageType.ERROR
+    assert reply.reply_serial == msg.serial
+    assert reply.signature == "as"
+    assert bus.unique_name in reply.body[0]
+
+    bus.disconnect()
+
+
+@pytest.mark.asyncio
 async def test_sending_messages_between_buses():
     bus1 = await MessageBus().connect()
     bus2 = await MessageBus().connect()

--- a/tests/test_aio_low_level.py
+++ b/tests/test_aio_low_level.py
@@ -58,8 +58,7 @@ async def test_error_handling():
 
     assert reply.message_type == MessageType.ERROR
     assert reply.reply_serial == msg.serial
-    assert reply.signature == "as"
-    assert bus.unique_name in reply.body[0]
+    assert reply.signature == "s"
 
     bus.disconnect()
 


### PR DESCRIPTION
If we do not clear the exception retrieved flag on the disconnect future it will likely never be retrieved since wait_for_disconnect will never be called when the reply handler raises.