### PR TITLE
feat: use dbus-run-session to drop X11 dependency

### DIFF
--- a/.github/workflows/big_endian.yml
+++ b/.github/workflows/big_endian.yml
@@ -24,12 +24,12 @@ jobs:
             "uname -a &&
             lscpu | grep Endian &&
             apt-get -y update &&
-            apt-get -y install python3 git python3.8-venv dbus dbus-x11 python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0 &&
+            apt-get -y install python3 git python3.8-venv dbus-daemon python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0 &&
             python3 --version &&
             python3 -c 'import sys; print(sys.byteorder)' &&
             pip3 install poetry &&
             git clone https://github.com/bluetooth-devices/dbus-fast &&
             cd dbus-fast &&
             poetry install --only=main,dev &&
-            export $(dbus-launch); poetry run pytest --cov-report=xml --timeout=5
+            dbus-run-session -- poetry run pytest --cov-report=xml --timeout=5
             "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Update apt
         run: sudo apt update
       - name: Install libs
-        run: sudo apt-get install -y dbus dbus-x11 python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+        run: sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python
@@ -70,7 +70,7 @@ jobs:
             REQUIRE_CYTHON=1 poetry install --only=main,dev
           fi
       - name: Test with Pytest
-        run: export $(dbus-launch); poetry run pytest --cov-report=xml --timeout=5
+        run: dbus-run-session -- poetry run pytest --cov-report=xml --timeout=5
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
The dbus-run-session helper allows to run a session scoped D-Bus daemon without X11 dependency.