### PR TITLE
fix: add missing cython version pin to the build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,5 +101,5 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ['setuptools>=65.4.1', 'wheel', 'Cython', "poetry-core>=1.0.0"]
+requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=0.29.32,<3.1.0', "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
related comment: https://github.com/Bluetooth-Devices/dbus-fast/pull/264#issuecomment-2334550288