### PR TITLE
feat: speed up unmarshalling headers

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -22,7 +22,18 @@ cdef unsigned int HEADER_SIGNATURE_SIZE
 cdef unsigned int LITTLE_ENDIAN
 cdef unsigned int BIG_ENDIAN
 cdef unsigned int PROTOCOL_VERSION
+
+
+cdef unsigned int HEADER_PATH_IDX
+cdef unsigned int HEADER_INTERFACE_IDX
+cdef unsigned int HEADER_MEMBER_IDX
+cdef unsigned int HEADER_ERROR_NAME_IDX
+cdef unsigned int HEADER_REPLY_SERIAL_IDX
+cdef unsigned int HEADER_DESTINATION_IDX
+cdef unsigned int HEADER_SENDER_IDX
+cdef unsigned int HEADER_SIGNATURE_IDX
 cdef unsigned int HEADER_UNIX_FDS_IDX
+
 cdef cython.list HEADER_IDX_TO_ARG_NAME
 
 cdef str UINT32_CAST
@@ -94,6 +105,8 @@ cdef unsigned int TOKEN_LEFT_PAREN_AS_INT
 
 cdef object MARSHALL_STREAM_END_ERROR
 cdef object DEFAULT_BUFFER_SIZE
+
+cdef list _EMPTY_HEADERS
 
 cdef cython.uint EAGAIN
 cdef cython.uint EWOULDBLOCK
@@ -222,9 +235,10 @@ cdef class Unmarshaller:
 
     @cython.locals(
         body=cython.list,
-        header_fields=cython.dict,
+        header_fields=cython.list,
         token_as_int=cython.uint,
         signature=cython.str,
+        message=Message
     )
     cdef _read_body(self)
 
@@ -237,5 +251,6 @@ cdef class Unmarshaller:
         o=cython.ulong,
         token_as_int=cython.uint,
         signature_len=cython.uint,
+        headers=cython.list
     )
-    cdef cython.dict _header_fields(self, unsigned int header_length)
+    cdef cython.list _header_fields(self, unsigned int header_length)

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -750,25 +750,21 @@ class Unmarshaller:
         flags = MESSAGE_FLAG_MAP.get(self._flag)
         if flags is None:
             flags = MESSAGE_FLAG_INTENUM(self._flag)
-        message = Message(
-            header_fields[HEADER_DESTINATION_IDX],
-            header_fields[HEADER_PATH_IDX],
-            header_fields[HEADER_INTERFACE_IDX],
-            header_fields[HEADER_MEMBER_IDX],
-            MESSAGE_TYPE_MAP[self._message_type],
-            flags,
-            None,
-            0,
-            header_fields[HEADER_SENDER_IDX],
-            self._unix_fds,
-            tree,
-            body,
-            self._serial,
+        self._message = Message(
+            message_type=MESSAGE_TYPE_MAP[self._message_type],
+            flags=flags,
+            unix_fds=self._unix_fds,
+            signature=tree,
+            body=body,
+            serial=self._serial,
             # The D-Bus implementation already validates the message,
             # so we don't need to do it again.
-            False,
+            validate=False,
+            destination=header_fields[HEADER_DESTINATION_IDX],
+            path=header_fields[HEADER_PATH_IDX],
+            interface=header_fields[HEADER_INTERFACE_IDX],
+            member=header_fields[HEADER_MEMBER_IDX],
         )
-        self._message = message
         self._read_complete = True
 
     def unmarshall(self) -> Optional[Message]:

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -750,8 +750,7 @@ class Unmarshaller:
         flags = MESSAGE_FLAG_MAP.get(self._flag)
         if flags is None:
             flags = MESSAGE_FLAG_INTENUM(self._flag)
-        message = Message.__new__(Message)
-        message._fast_init(
+        message = Message(
             header_fields[HEADER_DESTINATION_IDX],
             header_fields[HEADER_PATH_IDX],
             header_fields[HEADER_INTERFACE_IDX],

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -705,7 +705,7 @@ class Unmarshaller:
         self._pos = HEADER_ARRAY_OF_STRUCT_SIGNATURE_POSITION
         header_fields = self._header_fields(self._header_len)
         self._pos += -self._pos & 7  # align 8
-        signature = header_fields.pop("signature", "")
+        signature = header_fields[HEADER_SIGNATURE_IDX]
         if not self._body_len:
             tree = SIGNATURE_TREE_EMPTY
             body: list[Any] = []

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -770,6 +770,7 @@ class Unmarshaller:
             False,
         )
         self._message = message
+        self._read_complete = True
 
     def unmarshall(self) -> Optional[Message]:
         """Unmarshall the message.

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -764,6 +764,9 @@ class Unmarshaller:
             path=header_fields[HEADER_PATH_IDX],
             interface=header_fields[HEADER_INTERFACE_IDX],
             member=header_fields[HEADER_MEMBER_IDX],
+            reply_serial=header_fields[HEADER_REPLY_SERIAL_IDX],
+            error_name=header_fields[HEADER_ERROR_NAME_IDX],
+            sender=header_fields[HEADER_SENDER_IDX],
         )
         self._read_complete = True
 

--- a/src/dbus_fast/message.pxd
+++ b/src/dbus_fast/message.pxd
@@ -43,7 +43,7 @@ cdef class Message:
     cdef public object error_name
     cdef public object reply_serial
     cdef public object sender
-    cdef public cython.list unix_fds
+    cdef public list unix_fds
     cdef public object signature
     cdef public object signature_tree
     cdef public object body
@@ -66,9 +66,9 @@ cdef class Message:
         object error_name,
         object reply_serial,
         object sender,
-        object unix_fds,
+        list unix_fds,
         object signature_tree,
         object body,
         object serial,
-        object validate
+        bint validate
     )

--- a/src/dbus_fast/message.pxd
+++ b/src/dbus_fast/message.pxd
@@ -41,34 +41,16 @@ cdef class Message:
     cdef public object message_type
     cdef public object flags
     cdef public object error_name
-    cdef public unsigned int reply_serial
+    cdef public object reply_serial
     cdef public object sender
-    cdef public list unix_fds
+    cdef public cython.list unix_fds
     cdef public object signature
     cdef public object signature_tree
     cdef public object body
-    cdef public unsigned int serial
+    cdef public object serial
 
     @cython.locals(
         body_buffer=cython.bytearray,
         header_buffer=cython.bytearray
     )
     cpdef _marshall(self, object negotiate_unix_fd)
-
-    cdef _fast_init(
-        self,
-        object destination,
-        object path,
-        object interface,
-        object member,
-        object message_type,
-        object flags,
-        object error_name,
-        unsigned int reply_serial,
-        object sender,
-        list unix_fds,
-        object signature_tree,
-        object body,
-        unsigned int serial,
-        bint validate
-    )

--- a/src/dbus_fast/message.pxd
+++ b/src/dbus_fast/message.pxd
@@ -41,13 +41,13 @@ cdef class Message:
     cdef public object message_type
     cdef public object flags
     cdef public object error_name
-    cdef public object reply_serial
+    cdef public unsigned int reply_serial
     cdef public object sender
     cdef public list unix_fds
     cdef public object signature
     cdef public object signature_tree
     cdef public object body
-    cdef public object serial
+    cdef public unsigned int serial
 
     @cython.locals(
         body_buffer=cython.bytearray,
@@ -64,11 +64,11 @@ cdef class Message:
         object message_type,
         object flags,
         object error_name,
-        object reply_serial,
+        unsigned int reply_serial,
         object sender,
         list unix_fds,
         object signature_tree,
         object body,
-        object serial,
+        unsigned int serial,
         bint validate
     )

--- a/src/dbus_fast/message.pxd
+++ b/src/dbus_fast/message.pxd
@@ -54,3 +54,21 @@ cdef class Message:
         header_buffer=cython.bytearray
     )
     cpdef _marshall(self, object negotiate_unix_fd)
+
+    cdef _fast_init(
+        self,
+        object destination,
+        object path,
+        object interface,
+        object member,
+        object message_type,
+        object flags,
+        object error_name,
+        object reply_serial,
+        object sender,
+        object unix_fds,
+        object signature_tree,
+        object body,
+        object serial,
+        object validate
+    )

--- a/src/dbus_fast/message.py
+++ b/src/dbus_fast/message.py
@@ -34,14 +34,6 @@ MESSAGE_FLAG_NONE = MessageFlag.NONE
 MESSAGE_TYPE_METHOD_CALL = MessageType.METHOD_CALL
 
 
-_int = int
-_str = str
-_bool = bool
-_MessageType = MessageType
-_MessageFlag = MessageFlag
-_list = list
-
-
 class Message:
     """A class for sending and receiving messages through the
     :class:`MessageBus <dbus_fast.message_bus.BaseMessageBus>` with the
@@ -123,59 +115,26 @@ class Message:
         serial: int = 0,
         validate: bool = True,
     ) -> None:
-        if type(signature) is SignatureTree:
-            signature = signature.signature
-            signature_tree = signature
-        else:
-            signature_tree = get_signature_tree(signature or "")
-        self._fast_init(
-            destination,
-            path,
-            interface,
-            member,
-            message_type,
-            flags if type(flags) is MESSAGE_FLAG else MESSAGE_FLAG(flags),
-            str(error_name.value) if type(error_name) is ErrorType else error_name,
-            reply_serial or 0,
-            sender,
-            unix_fds,
-            signature_tree,
-            body,
-            serial or 0,
-            validate,
-        )
-
-    def _fast_init(
-        self,
-        destination: Optional[_str],
-        path: Optional[_str],
-        interface: Optional[_str],
-        member: Optional[_str],
-        message_type: _MessageType,
-        flags: _MessageFlag,
-        error_name: Optional[_str],
-        reply_serial: _int,
-        sender: _str,
-        unix_fds: _list[int],
-        signature_tree: SignatureTree,
-        body: _list[Any],
-        serial: _int,
-        validate: _bool,
-    ) -> None:
         self.destination = destination
         self.path = path
         self.interface = interface
         self.member = member
         self.message_type = message_type
-        self.flags = flags
-        self.error_name = error_name
-        self.reply_serial = reply_serial
+        self.flags = flags if type(flags) is MESSAGE_FLAG else MESSAGE_FLAG(flags)
+        self.error_name = (
+            str(error_name.value) if type(error_name) is ErrorType else error_name
+        )
+        self.reply_serial = reply_serial or 0
         self.sender = sender
         self.unix_fds = unix_fds
-        self.signature = signature_tree.signature
-        self.signature_tree = signature_tree
+        if type(signature) is SignatureTree:
+            self.signature = signature.signature
+            self.signature_tree = signature
+        else:
+            self.signature = signature or ""  # type: ignore[assignment]
+            self.signature_tree = get_signature_tree(signature or "")
         self.body = body
-        self.serial = serial
+        self.serial = serial or 0
 
         if not validate:
             return

--- a/src/dbus_fast/message.py
+++ b/src/dbus_fast/message.py
@@ -34,6 +34,14 @@ MESSAGE_FLAG_NONE = MessageFlag.NONE
 MESSAGE_TYPE_METHOD_CALL = MessageType.METHOD_CALL
 
 
+_int = int
+_str = str
+_bool = bool
+_MessageType = MessageType
+_MessageFlag = MessageFlag
+_list = list
+
+
 class Message:
     """A class for sending and receiving messages through the
     :class:`MessageBus <dbus_fast.message_bus.BaseMessageBus>` with the
@@ -115,26 +123,59 @@ class Message:
         serial: int = 0,
         validate: bool = True,
     ) -> None:
+        if type(signature) is SignatureTree:
+            signature = signature.signature
+            signature_tree = signature
+        else:
+            signature_tree = get_signature_tree(signature or "")
+        self._fast_init(
+            destination,
+            path,
+            interface,
+            member,
+            message_type,
+            flags if type(flags) is MESSAGE_FLAG else MESSAGE_FLAG(flags),
+            str(error_name.value) if type(error_name) is ErrorType else error_name,
+            reply_serial or 0,
+            sender,
+            unix_fds,
+            signature_tree,
+            body,
+            serial or 0,
+            validate,
+        )
+
+    def _fast_init(
+        self,
+        destination: Optional[_str],
+        path: Optional[_str],
+        interface: Optional[_str],
+        member: Optional[_str],
+        message_type: _MessageType,
+        flags: _MessageFlag,
+        error_name: Optional[_str],
+        reply_serial: _int,
+        sender: _str,
+        unix_fds: _list[int],
+        signature_tree: SignatureTree,
+        body: _list[Any],
+        serial: _int,
+        validate: _bool,
+    ) -> None:
         self.destination = destination
         self.path = path
         self.interface = interface
         self.member = member
         self.message_type = message_type
-        self.flags = flags if type(flags) is MESSAGE_FLAG else MESSAGE_FLAG(flags)
-        self.error_name = (
-            str(error_name.value) if type(error_name) is ErrorType else error_name
-        )
-        self.reply_serial = reply_serial or 0
+        self.flags = flags
+        self.error_name = error_name
+        self.reply_serial = reply_serial
         self.sender = sender
         self.unix_fds = unix_fds
-        if type(signature) is SignatureTree:
-            self.signature = signature.signature
-            self.signature_tree = signature
-        else:
-            self.signature = signature or ""  # type: ignore[assignment]
-            self.signature_tree = get_signature_tree(signature or "")
+        self.signature = signature_tree.signature
+        self.signature_tree = signature_tree
         self.body = body
-        self.serial = serial or 0
+        self.serial = serial
 
         if not validate:
             return

--- a/src/dbus_fast/message.py
+++ b/src/dbus_fast/message.py
@@ -107,12 +107,12 @@ class Message:
         message_type: MessageType = MESSAGE_TYPE_METHOD_CALL,
         flags: Union[MessageFlag, int] = MESSAGE_FLAG_NONE,
         error_name: Optional[Union[str, ErrorType]] = None,
-        reply_serial: int = 0,
+        reply_serial: Optional[int] = None,
         sender: Optional[str] = None,
         unix_fds: list[int] = [],
         signature: Optional[Union[SignatureTree, str]] = None,
         body: list[Any] = [],
-        serial: int = 0,
+        serial: Optional[int] = None,
         validate: bool = True,
     ) -> None:
         self.destination = destination


### PR DESCRIPTION
- Headers are always a fixed set so we can store them in a positional list instead of a `dict`