### PR TITLE
fix: ignore asyncio warnings in test_aio_proxy_object

### DIFF
--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from logging.handlers import QueueHandler
 from queue import SimpleQueue
-
+import asyncio
 import pytest
 
 import dbus_fast.introspection as intr
@@ -100,6 +100,7 @@ async def test_aio_proxy_object():
 
     # In addition to the exception passing through, we need to verify that
     # the exception doesn't trigger logging errors.
+    await asyncio.sleep(0)
     log_error_queue = SimpleQueue()
     log_handler = QueueHandler(log_error_queue)
     logger = logging.getLogger()

--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -118,7 +118,13 @@ async def test_aio_proxy_object():
     finally:
         logger.removeHandler(log_handler)
 
-    assert log_error_queue.empty(), log_error_queue.get_nowait()
+    messages = []
+    while not log_error_queue.empty():
+        message: logging.LogRecord = log_error_queue.get_nowait()
+        if message.module == "asyncio":
+            continue
+        messages.append(message)
+    assert not messages
 
     bus.disconnect()
     bus2.disconnect()


### PR DESCRIPTION
This sometimes test fails on py3.13 due to a race when the exception does not get retrieved.