### PR TITLE
feat: speed up marshalling messages

### DIFF
--- a/src/dbus_fast/message.pxd
+++ b/src/dbus_fast/message.pxd
@@ -50,8 +50,9 @@ cdef class Message:
     cdef public unsigned int serial
 
     @cython.locals(
-        body_buffer=cython.bytearray,
-        header_buffer=cython.bytearray
+        body_buffer=bytearray,
+        header_buffer=bytearray,
+        var=Variant
     )
     cpdef _marshall(self, object negotiate_unix_fd)
 

--- a/src/dbus_fast/message.py
+++ b/src/dbus_fast/message.py
@@ -325,21 +325,37 @@ class Message:
         # Variant is invalid.
 
         if self.path:
-            fields.append([HEADER_PATH, Variant("o", self.path, False)])
+            var = Variant.__new__(Variant)
+            var._init_variant("o", self.path, False)
+            fields.append([HEADER_PATH, var])
         if self.interface:
-            fields.append([HEADER_INTERFACE, Variant("s", self.interface, False)])
+            var = Variant.__new__(Variant)
+            var._init_variant("s", self.interface, False)
+            fields.append([HEADER_INTERFACE, var])
         if self.member:
-            fields.append([HEADER_MEMBER, Variant("s", self.member, False)])
+            var = Variant.__new__(Variant)
+            var._init_variant("s", self.member, False)
+            fields.append([HEADER_MEMBER, var])
         if self.error_name:
-            fields.append([HEADER_ERROR_NAME, Variant("s", self.error_name, False)])
+            var = Variant.__new__(Variant)
+            var._init_variant("s", self.error_name, False)
+            fields.append([HEADER_ERROR_NAME, var])
         if self.reply_serial:
-            fields.append([HEADER_REPLY_SERIAL, Variant("u", self.reply_serial, False)])
+            var = Variant.__new__(Variant)
+            var._init_variant("u", self.reply_serial, False)
+            fields.append([HEADER_REPLY_SERIAL, var])
         if self.destination:
-            fields.append([HEADER_DESTINATION, Variant("s", self.destination, False)])
+            var = Variant.__new__(Variant)
+            var._init_variant("s", self.destination, False)
+            fields.append([HEADER_DESTINATION, var])
         if self.signature:
-            fields.append([HEADER_SIGNATURE, Variant("g", self.signature, False)])
+            var = Variant.__new__(Variant)
+            var._init_variant("g", self.signature, False)
+            fields.append([HEADER_SIGNATURE, var])
         if self.unix_fds and negotiate_unix_fd:
-            fields.append([HEADER_UNIX_FDS, Variant("u", len(self.unix_fds), False)])
+            var = Variant.__new__(Variant)
+            var._init_variant("u", len(self.unix_fds), False)
+            fields.append([HEADER_UNIX_FDS, var])
 
         header_body = [
             LITTLE_ENDIAN,


### PR DESCRIPTION
We don't have a direct benchmark for this path yet. Its going to be faster to call the cdef than jumping back to python. The imporvement will be similar to the unmarshall side
<img width="364" alt="Screenshot 2025-01-07 at 12 49 41 PM" src="https://github.com/user-attachments/assets/dfe03214-5a15-4da6-8d6a-b5ca17109ed8" />

