### PR TITLE
fix: revert avoid building wheels if a release is not made

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,6 @@ jobs:
       - test
       - lint
       - commitlint
-    outputs:
-      released: ${{ steps.release.outputs.released }}
 
     steps:
       - uses: actions/checkout@v3
@@ -128,7 +126,7 @@ jobs:
 
   build_wheels:
     needs: [release]
-    if: needs.release.outputs.released == 'true'
+
     name: Build wheels on ${{ matrix.os }} with arch ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Reverts Bluetooth-Devices/dbus-fast#355