### PR TITLE
fix: attempting to unmarshall some arrays twice

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -587,7 +587,7 @@ class Unmarshaller:
                     self._pos += -self._pos & 7  # align 8
                     key = self._read_uint16_unpack()
                     result_dict[key] = self._read_variant()
-            if (
+            elif (
                 child_0_token_as_int == TOKEN_O_AS_INT
                 or child_0_token_as_int == TOKEN_S_AS_INT
             ) and child_1_token_as_int == TOKEN_A_AS_INT:


### PR DESCRIPTION
The loop would never be entered so it did not break but it would do some unneed dict lookups
<img width="370" alt="Screenshot 2025-02-01 at 10 43 27 PM" src="https://github.com/user-attachments/assets/c08e7647-c975-43ae-818a-1d8f27d0ba72" />

