### PR TITLE
feat: speed up bytearray creation in unmarshaller

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -243,7 +243,7 @@ class Unmarshaller:
         negotiate_unix_fd: bool = True,
     ) -> None:
         self._unix_fds: list[int] = []
-        self._buf = bytearray()  # Actual buffer
+        self._buf = bytearray.__new__(bytearray)  # Actual buffer
         self._stream = stream
         self._sock = sock
         self._message: Optional[Message] = None
@@ -280,7 +280,7 @@ class Unmarshaller:
         self._unix_fds = []
         to_clear = HEADER_SIGNATURE_SIZE + self._msg_len
         if len(self._buf) == to_clear:
-            self._buf = bytearray()
+            self._buf = bytearray.__new__(bytearray)
         else:
             del self._buf[:to_clear]
         self._msg_len = 0  # used to check if we have ready the header


### PR DESCRIPTION
Instead of calling the constprop, let cython use the new path
<img width="368" alt="Screenshot 2025-02-01 at 11 29 15 PM" src="https://github.com/user-attachments/assets/71f67555-fa01-4ac6-9927-f8815e19d8ca" />
