### PR TITLE
feat: build macos arm wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,8 +162,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04-arm, ubuntu-latest]
+        os: [ubuntu-24.04-arm, ubuntu-latest, macos-latest]
         musl: ["", "musllinux"]
+        exclude:
+          - os: macos-latest
+            musl: "musllinux"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The wheel build on `macos-latest` seems to be fine.
Tested it on my fork: https://github.com/cdce8p/dbus-fast/actions/runs/13159290301/job/36723708766