### PR TITLE
feat: make interface optional on method calls

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -922,7 +922,7 @@ class BaseMessageBus:
     def _find_message_handler(
         self, msg: _Message
     ) -> Optional[Callable[[Message, Callable[[Message], None]], None]]:
-        if "org.freedesktop.DBus." in msg.interface:
+        if msg.interface is not None and "org.freedesktop.DBus." in msg.interface:
             if (
                 msg.interface == "org.freedesktop.DBus.Introspectable"
                 and msg.member == "Introspect"
@@ -957,7 +957,7 @@ class BaseMessageBus:
                         continue
 
                     if (
-                        msg.interface == interface.name
+                        msg.interface in (None, interface.name)
                         and msg.member == method.name
                         and msg.signature == method.in_signature
                     ):


### PR DESCRIPTION
The dbus spec allows the interface to be optional on method calls. In that case, allow the message to match on any method with a matching name and signature.

https://github.com/Bluetooth-Devices/dbus-fast/issues/315