### PR TITLE
fix: correct size of uint32 with cython

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -117,7 +117,7 @@ cdef cython.uint EWOULDBLOCK
 cdef get_signature_tree
 
 
-cdef unsigned long _ustr_uint32(const unsigned char * buf, unsigned int offset, unsigned int endian) noexcept
+cdef unsigned int _ustr_uint32(const unsigned char * buf, unsigned int offset, unsigned int endian) noexcept
 
 cdef short _ustr_int16(const unsigned char * buf, unsigned int offset, unsigned int endian) noexcept
 

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -47,7 +47,7 @@ def test_bytearray_to_int16_big_end():
     assert buffer_to_int16(bytearray(b"\x01\x02"), 0, BIG_ENDIAN) == 258
     assert (
         buffer_to_int16(
-            bytearray((32768).to_bytes(2, byteorder="big", signed=False)), 0, BIG_ENDIAN
+            bytearray((32768).to_bytes(2, byteorder="big", signed=True)), 0, BIG_ENDIAN
         )
         == 32768
     )
@@ -58,7 +58,7 @@ def test_bytearray_to_int16_big_end_signed():
     assert buffer_to_int16(bytearray(b"\xff\xff"), 0, BIG_ENDIAN) == -1
     assert (
         buffer_to_int16(
-            bytearray((-32768).to_bytes(2, byteorder="big", signed=False)),
+            bytearray((-32768).to_bytes(2, byteorder="big", signed=True)),
             0,
             BIG_ENDIAN,
         )
@@ -96,7 +96,7 @@ def test_bytearray_to_int16_little_end():
     assert buffer_to_int16(bytearray(b"\x01\x02"), 0, LITTLE_ENDIAN) == 513
     assert (
         buffer_to_int16(
-            bytearray((32768).to_bytes(2, byteorder="little", signed=False)),
+            bytearray((32768).to_bytes(2, byteorder="little", signed=True)),
             0,
             LITTLE_ENDIAN,
         )
@@ -109,7 +109,7 @@ def test_bytearray_to_int16_little_end_signed():
     assert buffer_to_int16(bytearray(b"\xff\xff"), 0, LITTLE_ENDIAN) == -1
     assert (
         buffer_to_int16(
-            bytearray((-32768).to_bytes(2, byteorder="little", signed=False)),
+            bytearray((-32768).to_bytes(2, byteorder="little", signed=True)),
             0,
             LITTLE_ENDIAN,
         )

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -21,38 +21,100 @@ from dbus_fast.unpack import unpack_variants
 
 def test_bytearray_to_uint32_big_end():
     assert buffer_to_uint32(bytearray(b"\x01\x02\x03\x04"), 0, BIG_ENDIAN) == 16909060
+    assert (
+        buffer_to_uint32(
+            bytearray((0xFFFFFFFF).to_bytes(4, byteorder="big", signed=False)),
+            0,
+            BIG_ENDIAN,
+        )
+        == 0xFFFFFFFF
+    )
 
 
 def test_bytearray_to_uint16_big_end():
     assert buffer_to_uint16(bytearray(b"\x01\x02"), 0, BIG_ENDIAN) == 258
+    assert (
+        buffer_to_uint16(
+            bytearray((0xFFFF).to_bytes(2, byteorder="big", signed=False)),
+            0,
+            BIG_ENDIAN,
+        )
+        == 0xFFFF
+    )
 
 
 def test_bytearray_to_int16_big_end():
     assert buffer_to_int16(bytearray(b"\x01\x02"), 0, BIG_ENDIAN) == 258
+    assert (
+        buffer_to_int16(
+            bytearray((32768).to_bytes(2, byteorder="big", signed=False)), 0, BIG_ENDIAN
+        )
+        == 32768
+    )
 
 
 @pytest.mark.skipif(not is_compiled(), reason="requires cython")
 def test_bytearray_to_int16_big_end_signed():
     assert buffer_to_int16(bytearray(b"\xff\xff"), 0, BIG_ENDIAN) == -1
+    assert (
+        buffer_to_int16(
+            bytearray((-32768).to_bytes(2, byteorder="big", signed=False)),
+            0,
+            BIG_ENDIAN,
+        )
+        == -32768
+    )
 
 
 def test_bytearray_to_uint32_little_end():
     assert (
         buffer_to_uint32(bytearray(b"\x01\x02\x03\x04"), 0, LITTLE_ENDIAN) == 67305985
     )
+    assert (
+        buffer_to_uint32(
+            bytearray((0xFFFFFFFF).to_bytes(4, byteorder="little", signed=False)),
+            0,
+            LITTLE_ENDIAN,
+        )
+        == 0xFFFFFFFF
+    )
 
 
 def test_bytearray_to_uint16_little_end():
     assert buffer_to_uint16(bytearray(b"\x01\x02"), 0, LITTLE_ENDIAN) == 513
+    assert (
+        buffer_to_uint16(
+            bytearray((0xFFFF).to_bytes(2, byteorder="little", signed=False)),
+            0,
+            LITTLE_ENDIAN,
+        )
+        == 0xFFFF
+    )
 
 
 def test_bytearray_to_int16_little_end():
     assert buffer_to_int16(bytearray(b"\x01\x02"), 0, LITTLE_ENDIAN) == 513
+    assert (
+        buffer_to_int16(
+            bytearray((32768).to_bytes(2, byteorder="little", signed=False)),
+            0,
+            LITTLE_ENDIAN,
+        )
+        == 32768
+    )
 
 
 @pytest.mark.skipif(not is_compiled(), reason="requires cython")
 def test_bytearray_to_int16_little_end_signed():
     assert buffer_to_int16(bytearray(b"\xff\xff"), 0, LITTLE_ENDIAN) == -1
+    assert (
+        buffer_to_int16(
+            bytearray((-32768).to_bytes(2, byteorder="little", signed=False)),
+            0,
+            LITTLE_ENDIAN,
+        )
+        == -32768
+    )
 
 
 def print_buf(buf):

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -47,9 +47,9 @@ def test_bytearray_to_int16_big_end():
     assert buffer_to_int16(bytearray(b"\x01\x02"), 0, BIG_ENDIAN) == 258
     assert (
         buffer_to_int16(
-            bytearray((32768).to_bytes(2, byteorder="big", signed=True)), 0, BIG_ENDIAN
+            bytearray((32767).to_bytes(2, byteorder="big", signed=True)), 0, BIG_ENDIAN
         )
-        == 32768
+        == 32767
     )
 
 
@@ -96,11 +96,11 @@ def test_bytearray_to_int16_little_end():
     assert buffer_to_int16(bytearray(b"\x01\x02"), 0, LITTLE_ENDIAN) == 513
     assert (
         buffer_to_int16(
-            bytearray((32768).to_bytes(2, byteorder="little", signed=True)),
+            bytearray((32767).to_bytes(2, byteorder="little", signed=True)),
             0,
             LITTLE_ENDIAN,
         )
-        == 32768
+        == 32767
     )
 
 


### PR DESCRIPTION
This should have been an `unsigned int` not an `unsigned long`