### PR TITLE
feat: improve unmarshall performance for SignatureType

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -607,7 +607,7 @@ class Unmarshaller:
             )
         else:
             array_length = self._uint32_unpack(self._buf, self._pos - UINT32_SIZE)[0]
-        child_type = type_.child_0
+        child_type = type_._child_0
         token_as_int = child_type.token_as_int
 
         if token_as_int in {
@@ -631,8 +631,8 @@ class Unmarshaller:
             result_dict: dict[Any, Any] = {}
             key: str | int
             beginning_pos = self._pos
-            child_0 = child_type.child_0
-            child_1 = child_type.child_1
+            child_0 = child_type._child_0
+            child_1 = child_type._child_1
             child_0_token_as_int = child_0.token_as_int
             child_1_token_as_int = child_1.token_as_int
             # Strings with variant values are the most common case

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -607,7 +607,7 @@ class Unmarshaller:
             )
         else:
             array_length = self._uint32_unpack(self._buf, self._pos - UINT32_SIZE)[0]
-        child_type: SignatureType = type_.children[0]
+        child_type = type_.child_0
         token_as_int = child_type.token_as_int
 
         if token_as_int in {
@@ -631,9 +631,8 @@ class Unmarshaller:
             result_dict: dict[Any, Any] = {}
             key: str | int
             beginning_pos = self._pos
-            children = child_type.children
-            child_0 = children[0]
-            child_1 = children[1]
+            child_0 = child_type.child_0
+            child_1 = child_type.child_1
             child_0_token_as_int = child_0.token_as_int
             child_1_token_as_int = child_1.token_as_int
             # Strings with variant values are the most common case

--- a/src/dbus_fast/signature.pxd
+++ b/src/dbus_fast/signature.pxd
@@ -9,6 +9,8 @@ cdef class SignatureType:
     cdef public unsigned int token_as_int
     cdef public list children
     cdef str _signature
+    cdef public SignatureType child_0
+    cdef public SignatureType child_1
 
 
 cdef class SignatureTree:

--- a/src/dbus_fast/signature.pxd
+++ b/src/dbus_fast/signature.pxd
@@ -9,8 +9,8 @@ cdef class SignatureType:
     cdef public unsigned int token_as_int
     cdef public list children
     cdef str _signature
-    cdef public SignatureType child_0
-    cdef public SignatureType child_1
+    cdef public SignatureType _child_0
+    cdef public SignatureType _child_1
 
 
 cdef class SignatureTree:

--- a/src/dbus_fast/signature.py
+++ b/src/dbus_fast/signature.py
@@ -22,9 +22,9 @@ class SignatureType:
 
     _tokens = "ybnqiuxtdsogavh({"
     __slots__ = (
+        "_child_0",
+        "_child_1",
         "_signature",
-        "child_0",
-        "child_1",
         "children",
         "token",
         "token_as_int",
@@ -35,8 +35,8 @@ class SignatureType:
         self.token: str = token
         self.token_as_int = ord(token)
         self.children: list[SignatureType] = []
-        self.child_0: Optional[SignatureType] = None
-        self.child_1: Optional[SignatureType] = None
+        self._child_0: Optional[SignatureType] = None
+        self._child_1: Optional[SignatureType] = None
         self._signature: Optional[str] = None
 
     def __eq__(self, other: object) -> bool:
@@ -75,10 +75,10 @@ class SignatureType:
         :param child: The child type to add.
         :type child: :class:`SignatureType`
         """
-        if self.child_0 is None:
-            self.child_0 = child
-        elif self.child_1 is None:
-            self.child_1 = child
+        if self._child_0 is None:
+            self._child_0 = child
+        elif self._child_1 is None:
+            self._child_1 = child
         self.children.append(child)
 
     @staticmethod

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -23,6 +23,15 @@ def test_multiple_simple():
         assert_simple_type("s", tree.types[i])
 
 
+def test_children():
+    tree = SignatureTree("ss")
+    assert len(tree.types) == 2
+    parent = tree.types[0]
+    assert parent.token == "s"
+    assert parent.signature == "s"
+    assert len(parent.children) == 0
+
+
 def test_array():
     tree = SignatureTree("as")
     assert len(tree.types) == 1
@@ -31,6 +40,11 @@ def test_array():
     assert child.token == "a"
     assert len(child.children) == 1
     assert_simple_type("s", child.children[0])
+    assert child.children[0].token == "s"
+    assert child._child_0.signature == "s"
+    assert child._child_1 is None
+    with pytest.raises(AttributeError):
+        _ = child._child_1.signature
 
 
 def test_array_multiple():
@@ -67,6 +81,8 @@ def test_simple_struct():
     assert len(child.children) == 3
     for i in range(3):
         assert_simple_type("s", child.children[i])
+    assert child._child_0.signature == "s"
+    assert child._child_1.signature == "s"
 
 
 def test_nested_struct():


### PR DESCRIPTION
This is ~3% faster

Todo

- [x] See how it's handled when it's still None `AttributeError: 'NoneType' object has no attribute 'signature'`
- [x] Add tests
- [x] Make child0 and 1 protected 