### PR TITLE
fix: Add missing type hint to Node.nodes attribute

### DIFF
--- a/src/dbus_fast/introspection.py
+++ b/src/dbus_fast/introspection.py
@@ -475,7 +475,7 @@ class Node:
             raise InvalidIntrospectionError('child nodes must have a "name" attribute')
 
         self.interfaces = interfaces if interfaces is not None else []
-        self.nodes = []
+        self.nodes: list[Node] = []
         self.name = name
         self.is_root = is_root
 


### PR DESCRIPTION
Add missing type hint to dbus_fast.introspection.Node.nodes attribute. The other attributes can be inferred by the initializer, but since nodes is an empty list, it needs an explicit type hint.