### PR TITLE
bug: fix Signal() name type hint

### DIFF
--- a/src/dbus_fast/introspection.py
+++ b/src/dbus_fast/introspection.py
@@ -132,7 +132,7 @@ class Signal:
 
     def __init__(
         self,
-        name: Optional[str],
+        name: str,
         args: Optional[list[Arg]] = None,
         annotations: Optional[dict[str, str]] = None,
     ):


### PR DESCRIPTION
Change Signal() name parameter type hint. The name is not optional.

Closes: https://github.com/Bluetooth-Devices/dbus-fast/issues/523