### PR TITLE
chore: remove bus._sock.close() from tests

### DIFF
--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -218,5 +218,3 @@ async def test_methods(interface_class):
 
     bus1.disconnect()
     bus2.disconnect()
-    bus1._sock.close()
-    bus2._sock.close()

--- a/tests/service/test_properties.py
+++ b/tests/service/test_properties.py
@@ -245,8 +245,6 @@ async def test_property_methods(interface_class):
 
     bus1.disconnect()
     bus2.disconnect()
-    bus1._sock.close()
-    bus2._sock.close()
 
 
 @pytest.mark.parametrize("interface_class", [ExampleInterface, AsyncInterface])
@@ -303,5 +301,3 @@ async def test_property_changed_signal(interface_class):
 
     bus1.disconnect()
     bus2.disconnect()
-    bus1._sock.close()
-    bus2._sock.close()

--- a/tests/service/test_signals.py
+++ b/tests/service/test_signals.py
@@ -161,8 +161,6 @@ async def test_signals():
 
     bus1.disconnect()
     bus2.disconnect()
-    bus1._sock.close()
-    bus2._sock.close()
 
 
 @pytest.mark.asyncio
@@ -257,5 +255,3 @@ async def test_interface_add_remove_signal():
 
     bus1.disconnect()
     bus2.disconnect()
-    bus1._sock.close()
-    bus2._sock.close()

--- a/tests/test_glib_low_level.py
+++ b/tests/test_glib_low_level.py
@@ -123,8 +123,6 @@ def test_sending_messages_between_buses():
 
     bus1.disconnect()
     bus2.disconnect()
-    bus1._sock.close()
-    bus2._sock.close()
 
 
 @pytest.mark.skipif(not has_gi, reason=skip_reason_no_gi)
@@ -180,5 +178,3 @@ def test_sending_signals_between_buses():
 
     bus1.disconnect()
     bus2.disconnect()
-    bus1._sock.close()
-    bus2._sock.close()


### PR DESCRIPTION
The tests already call bus.disconnect(), which internally calls self._sock.close(). Therefore, the explicit calls to bus._sock.close() are redundant and can be removed.