### PR TITLE
fix: close socket file handle to prevent resource leak

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import io
 import inspect
+import io
 import logging
 import socket
 import traceback


### PR DESCRIPTION
Close the `_socket` file handle in `BaseMessageBus._finalize()` to
prevent resource leaks. Prior to this fix, many warning similar to
the one below could be seen in the test output:

    tests/test_signature.py::test_array_multiple
    /usr/lib/python3.12/contextlib.py:132: ResourceWarning: unclosed <socket.socket fd=18, family=1, type=1, proto=0, raddr=/run/user/1000/bus>
        def __enter__(self):
    Enable tracemalloc to get traceback where the object was allocated.
    See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

Closes: https://github.com/Bluetooth-Devices/dbus-fast/issues/494