### PR TITLE
chore: ignore C files generated by Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Cython generated files
+*.c


### PR DESCRIPTION
Add .gitignore entry to ignore C files generated by Cython.