### PR TITLE
chore: replace asyncio.iscoroutinefunction with inspect.iscoroutinefunction

### DIFF
--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import array
 import asyncio
 import contextlib
+import inspect
 import logging
 import socket
 from collections import deque
@@ -450,7 +451,7 @@ class MessageBus(BaseMessageBus):
     def _make_method_handler(
         self, interface: ServiceInterface, method: _Method
     ) -> Callable[[Message, Callable[[Message], None]], None]:
-        if not asyncio.iscoroutinefunction(method.fn):
+        if not inspect.iscoroutinefunction(method.fn):
             return super()._make_method_handler(interface, method)
 
         negotiate_unix_fd = self._negotiate_unix_fd

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -601,7 +601,7 @@ class ServiceInterface:
     ) -> None:
         # XXX MUST CHECK TYPE RETURNED BY GETTER
         try:
-            if asyncio.iscoroutinefunction(prop.prop_getter):
+            if inspect.iscoroutinefunction(prop.prop_getter):
                 task: asyncio.Task = asyncio.ensure_future(prop.prop_getter(interface))
 
                 def get_property_callback(task_: asyncio.Task) -> None:
@@ -631,7 +631,7 @@ class ServiceInterface:
     ) -> None:
         # XXX MUST CHECK TYPE TO SET
         try:
-            if asyncio.iscoroutinefunction(prop.prop_setter):
+            if inspect.iscoroutinefunction(prop.prop_setter):
                 task: asyncio.Task = asyncio.ensure_future(
                     prop.prop_setter(interface, value)
                 )


### PR DESCRIPTION


`asyncio.iscoroutinefunction()` is deprecated in Python 3.13 and will be removed in Python 3.16. Replace its usage with `inspect.iscoroutinefunction()` to ensure compatibility with future Python versions.