### PR TITLE
chore: fix type hints in test_send_reply.py

### DIFF
--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
@@ -11,7 +12,7 @@ from dbus_fast.send_reply import SendReply
 
 
 @pytest.fixture(autouse=True)
-def mock_address() -> None:
+def mock_address() -> Generator[None, None, None]:
     original_address = os.environ.get("DBUS_SESSION_BUS_ADDRESS")
     os.environ["DBUS_SESSION_BUS_ADDRESS"] = "unix:path=/dev/null"
     yield
@@ -24,7 +25,7 @@ def mock_address() -> None:
 def test_send_reply_exception() -> None:
     """Test that SendReply sends an error message when DBusError is raised."""
 
-    messages = []
+    messages: list[Message] = []
 
     class MockBus(BaseMessageBus):
         def send(self, msg: Message) -> None:
@@ -55,7 +56,7 @@ def test_send_reply_exception() -> None:
 def test_send_reply_happy_path() -> None:
     """Test that SendReply sends a message."""
 
-    messages = []
+    messages: list[Message] = []
 
     class MockBus(BaseMessageBus):
         def send(self, msg: Message) -> None:


### PR DESCRIPTION
Fix wrong return type on `mock_address()` and add list type hints for `messages` variables to give the element type.