### PR TITLE
fix: enable freethreading in Cython modules

### DIFF
--- a/src/dbus_fast/_private/address.py
+++ b/src/dbus_fast/_private/address.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from __future__ import annotations
 
 import os

--- a/src/dbus_fast/_private/marshaller.py
+++ b/src/dbus_fast/_private/marshaller.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from __future__ import annotations
 
 import array

--- a/src/dbus_fast/aio/message_reader.py
+++ b/src/dbus_fast/aio/message_reader.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from __future__ import annotations
 
 import logging

--- a/src/dbus_fast/message.py
+++ b/src/dbus_fast/message.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from typing import Any
 
 from ._private.constants import LITTLE_ENDIAN, PROTOCOL_VERSION, HeaderField

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from __future__ import annotations
 
 import inspect

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from __future__ import annotations
 
 import asyncio

--- a/src/dbus_fast/signature.py
+++ b/src/dbus_fast/signature.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from collections.abc import Callable
 from functools import lru_cache
 from typing import Any

--- a/src/dbus_fast/unpack.py
+++ b/src/dbus_fast/unpack.py
@@ -1,3 +1,5 @@
+# cython: freethreading_compatible = True
+
 from typing import Any
 
 from .signature import Variant


### PR DESCRIPTION
Add the `# cython: freethreading_compatible = True` directive to Cython-compiled modules so that it doesn't enable the GIL.

https://cython.readthedocs.io/en/latest/src/userguide/freethreading.html#status

This changes generated code from `Py_MOD_GIL_USED` to `Py_MOD_GIL_NOT_USED`.