### PR TITLE
fix: fix service getter/setter tasks tracking

### DIFF
--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -41,6 +41,7 @@ class _MethodCallbackProtocol(Protocol):
 
 _background_tasks: set[asyncio.Task[Any]] = set()
 
+
 class _Method:
     def __init__(
         self, fn: _MethodCallbackProtocol, name: str, disabled: bool = False


### PR DESCRIPTION
Keep a handle to asyncio tasks created for service async property getters and setters to prevent them from being garbage collected before they complete.