### PR TITLE
chore: fix missing backtick in SignatureTree docstring

### DIFF
--- a/src/dbus_fast/signature.py
+++ b/src/dbus_fast/signature.py
@@ -353,7 +353,7 @@ class SignatureTree:  # noqa: PLW1641
     :vartype ~.signature: str
 
     :ivar root_type: The root type of this signature tree.
-    :vartype root_type: :class:`SignatureType
+    :vartype root_type: :class:`SignatureType`
 
     :raises:
         :class:`InvalidSignatureError` if the given signature is not valid.


### PR DESCRIPTION
Add a missing backtick in the docstring for the SignatureTree.

This was causing a sphinx-build warning:

    /home/david/work/pybricks/dbus-fast/src/dbus_fast/signature.py:docstring of dbus_fast.signature.SignatureTree:13: WARNING: Inline interpreted text or phrase reference start-string without end-string.