### PR TITLE
chore: remove stray `~.`s from the docs

### DIFF
--- a/src/dbus_fast/proxy_object.py
+++ b/src/dbus_fast/proxy_object.py
@@ -236,8 +236,8 @@ class BaseProxyObject:
     :vartype introspection: :class:`Node <dbus_fast.introspection.Node>`
     :ivar bus: The message bus this proxy object is connected to.
     :vartype bus: :class:`BaseMessageBus <dbus_fast.message_bus.BaseMessageBus>`
-    :ivar ~.ProxyInterface: The proxy interface class this proxy object uses.
-    :vartype ~.ProxyInterface: Type[:class:`BaseProxyInterface <dbus_fast.proxy_object.BaseProxyObject>`]
+    :ivar ProxyInterface: The proxy interface class this proxy object uses.
+    :vartype ProxyInterface: Type[:class:`BaseProxyInterface <dbus_fast.proxy_object.BaseProxyInterface>`]
     :ivar child_paths: A list of absolute object paths of the children of this object.
     :vartype child_paths: list(str)
 

--- a/src/dbus_fast/signature.py
+++ b/src/dbus_fast/signature.py
@@ -14,8 +14,8 @@ class SignatureType:  # noqa: PLW1641
     This class is not meant to be constructed directly. Use the :class:`SignatureTree`
     class to parse signatures.
 
-    :ivar ~.signature: The signature of this complete type.
-    :vartype ~.signature: str
+    :ivar signature: The signature of this complete type.
+    :vartype signature: str
 
     :ivar children: A list of child types if this is a container type. Arrays \
     have one child type, dict entries have two child types (key and value), and \
@@ -349,8 +349,8 @@ class SignatureTree:  # noqa: PLW1641
     :ivar types: A list of parsed complete types.
     :vartype types: list(:class:`SignatureType`)
 
-    :ivar ~.signature: The signature of this signature tree.
-    :vartype ~.signature: str
+    :ivar signature: The signature of this signature tree.
+    :vartype signature: str
 
     :ivar root_type: The root type of this signature tree.
     :vartype root_type: :class:`SignatureType


### PR DESCRIPTION
There were a couple of places where `~.` was in front of names in the documentation. Fix it.

Also fix link to BaseProxyInterface while we are touching the same line.