### PR TITLE
feat: add basic support for Annotated[...] DBus signature annotations

### DIFF
--- a/src/dbus_fast/_private/util.py
+++ b/src/dbus_fast/_private/util.py
@@ -120,7 +120,8 @@ def parse_annotation(annotation: str) -> str:
     if get_origin(annotation) == Annotated:
         try:
             annotation = get_args(annotation)[1]
-        except IndexError:
+        except IndexError:  # pragma: no cover
+            # should not be possible due Annotated always having >=1 args
             raise_value_error()
 
     if type(annotation) is not str:

--- a/tests/service/test_decorators.py
+++ b/tests/service/test_decorators.py
@@ -168,7 +168,7 @@ def test_interface_introspection():
     assert len(properties) == 2
 
 
-def test_method_decorator_rejects_invalid_annotated_signature():
+def test_method_decorator_rejects_annotated_non_string_metadata():
     with pytest.raises(
         ValueError, match="service annotations must be a string constant"
     ):
@@ -187,7 +187,21 @@ def test_method_decorator_rejects_invalid_annotated_signature():
                 return "x"
 
 
-def test_method_decorator_rejects_invalid_non_string_signature():
+def test_method_decorator_rejects_annotated_missing_metadata():
+    with pytest.raises(TypeError, match="should be used with at least two arguments"):
+
+        class Interface(ServiceInterface):
+            def __init__(self) -> None:
+                super().__init__("test.interface")
+
+            @dbus_method()
+            def bad_missing_metadata(
+                self, one: Annotated[str]
+            ):  # second parameter should always exists
+                return "x"
+
+
+def test_method_decorator_rejects_annotation_that_is_not_string_or_annotated():
     with pytest.raises(
         ValueError, match="service annotations must be a string constant"
     ):


### PR DESCRIPTION
This PR adds support for using PEP 593 Annotated types to define DBus signature annotations in dbus-fast.
https://peps.python.org/pep-0593/
https://typing.python.org/en/latest/spec/qualifiers.html#annotated

This allows combining Python type hints and DBus signatures in a single annotation, like the following one:

```bash
from typing import Annotated

def Version(self) -> Annotated[str, "s"]:
    return "1.0.0"
```

This change is mainly intended to support modern Python typing while preserving the existing dbus-fast string-based DBus signature notation.

This pr should be fully backwards-compatible, the existing code using plain string signatures continues to behave exactly as before.
