### PR TITLE
feat!: annotated types for D-Bus signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v4
       - name: Install libs
-        run: sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+        run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
       - uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
+        exclude: tests/service/test_methods.py
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.9
     hooks:

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ To define a service on the bus, use the `ServiceInterface` class and decorate cl
 For more information, see the [overview for the high-level service](https://dbus-fast.readthedocs.io/en/latest/high-level-service/index.html).
 
 ```python
+from dbus_fast.annotations import DBusStr, DBusDict
 from dbus_fast.service import ServiceInterface, method, dbus_property, signal, Variant
 from dbus_fast.aio MessageBus
 
@@ -129,11 +130,11 @@ class ExampleInterface(ServiceInterface):
         self._string_prop = 'kevin'
 
     @dbus_method()
-    def Echo(self, what: 's') -> 's':
+    def Echo(self, what: DBusStr) -> DBusStr:
         return what
 
     @dbus_method()
-    def GetVariantDict() -> 'a{sv}':
+    def GetVariantDict() -> DBusDict:
         return {
             'foo': Variant('s', 'bar'),
             'bat': Variant('x', -55),
@@ -141,15 +142,15 @@ class ExampleInterface(ServiceInterface):
         }
 
     @dbus_property()
-    def string_prop(self) -> 's':
+    def string_prop(self) -> DBusStr:
         return self._string_prop
 
     @string_prop.setter
-    def string_prop_setter(self, val: 's'):
+    def string_prop_setter(self, val: DBusStr):
         self._string_prop = val
 
     @dbus_signal()
-    def signal_simple(self) -> 's':
+    def signal_simple(self) -> DBusStr:
         return 'hello'
 
 async def main():

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ class ExampleInterface(ServiceInterface):
         return what
 
     @dbus_method()
-    def GetVariantDict() -> DBusDict:
+    def GetVariantDict(self) -> DBusDict:
         return {
             'foo': Variant('s', 'bar'),
             'bat': Variant('x', -55),

--- a/docs/source/high-level-service/index.rst
+++ b/docs/source/high-level-service/index.rst
@@ -78,7 +78,7 @@ constructor to use unix file descriptors.
 
 .. code-block:: python3
 
-    from dbus_fast.annotations import (DBusSignature, DBusBool, DBusByte, DBusInt,
+    from dbus_fast.annotations import (DBusSignature, DBusBool, DBusByte, DBusInt32,
                                        DBusStr)
     from dbus_fast.aio import MessageBus
     from dbus_fast.service import (ServiceInterface,
@@ -86,6 +86,7 @@ constructor to use unix file descriptors.
     from dbus_fast import Variant, DBusError
 
     import asyncio
+    from typing import Annotated
 
     FrobateReturnDBusType = Annotated[dict[int, str], DBusSignature("a{us}")]
     BazifyBarDBusType = Annotated[tuple[int, int, int], DBusSignature("(iiu)")]
@@ -98,7 +99,7 @@ constructor to use unix file descriptors.
             self._bar = 105
 
         @dbus_method()
-        def Frobate(self, foo: DBusInt, bar: DBusStr) -> FrobateReturnDBusType:
+        def Frobate(self, foo: DBusInt32, bar: DBusStr) -> FrobateReturnDBusType:
             print(f'called Frobate with foo={foo} and bar={bar}')
 
             return {

--- a/docs/source/high-level-service/index.rst
+++ b/docs/source/high-level-service/index.rst
@@ -78,6 +78,8 @@ constructor to use unix file descriptors.
 
 .. code-block:: python3
 
+    from dbus_fast.annotations import (DBusSignature, DBusBool, DBusByte, DBusInt,
+                                       DBusStr)
     from dbus_fast.aio import MessageBus
     from dbus_fast.service import (ServiceInterface,
                                    dbus_method, dbus_property, dbus_signal)
@@ -85,13 +87,18 @@ constructor to use unix file descriptors.
 
     import asyncio
 
+    FrobateReturnDBusType = Annotated[dict[int, str], DBusSignature("a{us}")]
+    BazifyBarDBusType = Annotated[tuple[int, int, int], DBusSignature("(iiu)")]
+    BazifyReturnDBusType = Annotated[tuple[Variant, Variant], DBusSignature("vv")]
+    MorgifyBarDBusType = Annotated[tuple[int, int, list[Variant]], DBusSignature("(iiav)")]
+
     class ExampleInterface(ServiceInterface):
         def __init__(self):
             super().__init__('com.example.SampleInterface0')
             self._bar = 105
 
         @dbus_method()
-        def Frobate(self, foo: 'i', bar: 's') -> 'a{us}':
+        def Frobate(self, foo: DBusInt, bar: DBusStr) -> FrobateReturnDBusType:
             print(f'called Frobate with foo={foo} and bar={bar}')
 
             return {
@@ -100,26 +107,26 @@ constructor to use unix file descriptors.
             }
 
         @dbus_method()
-        async def Bazify(self, bar: '(iiu)') -> 'vv':
+        async def Bazify(self, bar: BazifyBarDBusType) -> BazifyReturnDBusType:
             print(f'called Bazify with bar={bar}')
 
-            return [Variant('s', 'example'), Variant('s', 'bazify')]
+            return Variant('s', 'example'), Variant('s', 'bazify')
 
         @dbus_method()
-        def Mogrify(self, bar: '(iiav)'):
+        def Mogrify(self, bar: MorgifyBarDBusType):
             raise DBusError('com.example.error.CannotMogrify',
                             'it is not possible to mogrify')
 
         @dbus_signal()
-        def Changed(self) -> 'b':
+        def Changed(self) -> DBusBool:
             return True
 
         @dbus_property()
-        def Bar(self) -> 'y':
+        def Bar(self) -> DBusByte:
             return self._bar
 
         @Bar.setter
-        def Bar(self, val: 'y'):
+        def Bar(self, val: DBusByte):
             if self._bar == val:
                 return
 

--- a/docs/source/high-level-service/index.rst
+++ b/docs/source/high-level-service/index.rst
@@ -38,7 +38,7 @@ method will be provided by the calling client and will conform to the
 parameter type annotations. The value returned by the class method will
 be returned to the client and must conform to the return type annotation
 specified by the user. If the return annotation specifies more than one
-type, the values must be returned in a ``list``. When
+type, the values must be returned in a ``tuple``. When
 :class:`aio.MessageBus` is used, methods can be coroutines.
 
 A class method decorated with ``@dbus_property()`` will be exposed as a
@@ -58,7 +58,7 @@ DBus signal. The value returned by the class method will be emitted as a
 signal and broadcast to clients who are listening to the signal. The
 returned value must conform to the return annotation of the class method
 as a DBus signature string. If the signal has more than one argument,
-they must be returned within a ``list``.
+they must be returned within a ``tuple``.
 
 A class method decorated with ``@dbus_method()`` or ``@dbus_property()``
 may throw a :class:`DBusError <dbus_fast.DBusError>` to return a

--- a/docs/source/type-system/annotations.rst
+++ b/docs/source/type-system/annotations.rst
@@ -1,0 +1,6 @@
+Annotations
+===========
+
+.. automodule:: dbus_fast.annotations
+    :members:
+    :undoc-members:

--- a/docs/source/type-system/index.rst
+++ b/docs/source/type-system/index.rst
@@ -5,6 +5,7 @@ The Type System
    :maxdepth: 2
 
    variant
+   annotations
    signature-tree
    signature-type
 

--- a/examples/example-service.py
+++ b/examples/example-service.py
@@ -22,7 +22,7 @@ class ExampleInterface(ServiceInterface):
 
     @dbus_method()
     def EchoMultiple(self, what1: "s", what2: "s") -> "ss":
-        return [what1, what2]
+        return what1, what2
 
     @dbus_method()
     def GetVariantDict(self) -> "a{sv}":  # noqa: F722
@@ -46,7 +46,7 @@ class ExampleInterface(ServiceInterface):
 
     @dbus_signal()
     def signal_multiple(self) -> "ss":
-        return ["hello", "world"]
+        return "hello", "world"
 
 
 async def main():

--- a/examples/example-service.py
+++ b/examples/example-service.py
@@ -5,27 +5,31 @@ import sys
 sys.path.append(os.path.abspath(os.path.dirname(__file__) + "/.."))
 
 import asyncio
+from typing import Annotated
 
 from dbus_fast import Variant
 from dbus_fast.aio.message_bus import MessageBus
+from dbus_fast.annotations import DBusDict, DBusStr
 from dbus_fast.service import ServiceInterface, dbus_method, dbus_property, dbus_signal
 
 
 class ExampleInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
         self._string_prop = "kevin"
 
     @dbus_method()
-    def Echo(self, what: "s") -> "s":
+    def Echo(self, what: DBusStr) -> DBusStr:
         return what
 
     @dbus_method()
-    def EchoMultiple(self, what1: "s", what2: "s") -> "ss":
+    def EchoMultiple(
+        self, what1: DBusStr, what2: DBusStr
+    ) -> Annotated[tuple[DBusStr, DBusStr], "ss"]:
         return what1, what2
 
     @dbus_method()
-    def GetVariantDict(self) -> "a{sv}":  # noqa: F722
+    def GetVariantDict(self) -> DBusDict:
         return {
             "foo": Variant("s", "bar"),
             "bat": Variant("x", -55),
@@ -33,23 +37,23 @@ class ExampleInterface(ServiceInterface):
         }
 
     @dbus_property(name="StringProp")
-    def string_prop(self) -> "s":
+    def string_prop(self) -> DBusStr:
         return self._string_prop
 
     @string_prop.setter
-    def string_prop_setter(self, val: "s"):
+    def string_prop_setter(self, val: DBusStr) -> None:
         self._string_prop = val
 
     @dbus_signal()
-    def signal_simple(self) -> "s":
+    def signal_simple(self) -> DBusStr:
         return "hello"
 
     @dbus_signal()
-    def signal_multiple(self) -> "ss":
+    def signal_multiple(self) -> Annotated[tuple[DBusStr, DBusStr], "ss"]:
         return "hello", "world"
 
 
-async def main():
+async def main() -> None:
     name = "dbus.next.example.service"
     path = "/example/path"
     interface_name = "example.interface"

--- a/examples/example-service.py
+++ b/examples/example-service.py
@@ -25,7 +25,7 @@ class ExampleInterface(ServiceInterface):
     @dbus_method()
     def EchoMultiple(
         self, what1: DBusStr, what2: DBusStr
-    ) -> Annotated[tuple[DBusStr, DBusStr], DBusSignature("ss")]:
+    ) -> Annotated[tuple[str, str], DBusSignature("ss")]:
         return what1, what2
 
     @dbus_method()
@@ -51,7 +51,7 @@ class ExampleInterface(ServiceInterface):
     @dbus_signal()
     def signal_multiple(
         self,
-    ) -> Annotated[tuple[DBusStr, DBusStr], DBusSignature("ss")]:
+    ) -> Annotated[tuple[str, str], DBusSignature("ss")]:
         return "hello", "world"
 
 

--- a/examples/example-service.py
+++ b/examples/example-service.py
@@ -9,7 +9,7 @@ from typing import Annotated
 
 from dbus_fast import Variant
 from dbus_fast.aio.message_bus import MessageBus
-from dbus_fast.annotations import DBusDict, DBusStr
+from dbus_fast.annotations import DBusDict, DBusSignature, DBusStr
 from dbus_fast.service import ServiceInterface, dbus_method, dbus_property, dbus_signal
 
 
@@ -25,7 +25,7 @@ class ExampleInterface(ServiceInterface):
     @dbus_method()
     def EchoMultiple(
         self, what1: DBusStr, what2: DBusStr
-    ) -> Annotated[tuple[DBusStr, DBusStr], "ss"]:
+    ) -> Annotated[tuple[DBusStr, DBusStr], DBusSignature("ss")]:
         return what1, what2
 
     @dbus_method()
@@ -49,7 +49,7 @@ class ExampleInterface(ServiceInterface):
         return "hello"
 
     @dbus_signal()
-    def signal_multiple(self) -> Annotated[tuple[DBusStr, DBusStr], "ss"]:
+    def signal_multiple(self) -> Annotated[tuple[DBusStr, DBusStr], DBusSignature("ss")]:
         return "hello", "world"
 
 

--- a/examples/example-service.py
+++ b/examples/example-service.py
@@ -49,7 +49,9 @@ class ExampleInterface(ServiceInterface):
         return "hello"
 
     @dbus_signal()
-    def signal_multiple(self) -> Annotated[tuple[DBusStr, DBusStr], DBusSignature("ss")]:
+    def signal_multiple(
+        self,
+    ) -> Annotated[tuple[DBusStr, DBusStr], DBusSignature("ss")]:
         return "hello", "world"
 
 

--- a/src/dbus_fast/_private/util.py
+++ b/src/dbus_fast/_private/util.py
@@ -115,6 +115,13 @@ def parse_annotation(annotation: str) -> str:
 
     if not annotation or annotation is inspect.Signature.empty:
         return ""
+
+    # If there is __metadata__, it means this is typing.Annotated. In that case,
+    # the first item in __metadata__ should contain the D-Bus signature string.
+    metadata = getattr(annotation, "__metadata__", None)
+    if metadata is not None:
+        annotation = metadata[0]
+
     if type(annotation) is not str:
         raise_value_error()
     try:

--- a/src/dbus_fast/_private/util.py
+++ b/src/dbus_fast/_private/util.py
@@ -138,7 +138,7 @@ def parse_annotation(annotation: Any, module: Any) -> str:
             pass
 
         # Deferred evaluation of annotations, so evaluate it now.
-        annotation = eval(annotation, module.__dict__, {})
+        annotation = eval(annotation, module.__dict__, {})  # noqa: S307
 
     if get_origin(annotation) is Annotated:
         try:

--- a/src/dbus_fast/_private/util.py
+++ b/src/dbus_fast/_private/util.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import ast
 import inspect
+import re
 from collections.abc import Callable
-from typing import Any
+from typing import Annotated, Any, get_args, get_origin
+
+from dbus_fast.annotations import DBusSignature
 
 from ..signature import SignatureTree, SignatureType, Variant, get_signature_tree
 
@@ -99,7 +102,7 @@ def replace_idx_with_fds(
     return body
 
 
-def parse_annotation(annotation: str) -> str:
+def parse_annotation(annotation: Any, module: Any) -> str:
     """
     Because of PEP 563, if `from __future__ import annotations` is used in code
     or on Python version >=3.10 where this is the default, return annotations
@@ -108,32 +111,48 @@ def parse_annotation(annotation: str) -> str:
     constant.
     """
 
-    def raise_value_error() -> None:
-        raise ValueError(
-            f"service annotations must be a string constant (got {annotation})"
-        )
-
     if not annotation or annotation is inspect.Signature.empty:
         return ""
 
-    # If there is __metadata__, it means this is typing.Annotated. In that case,
-    # the first item in __metadata__ should contain the D-Bus signature string.
-    metadata = getattr(annotation, "__metadata__", None)
-    if metadata is not None:
-        annotation = metadata[0]
+    if type(annotation) is str:
+        # This is a bit annoying because strings are special in annotations
+        # because they are assumed to be forward references. There isn't really
+        # a way to distinguish between a string constant and a forward reference
+        # other than by heuristics.
 
-    if type(annotation) is not str:
-        raise_value_error()
-    try:
-        body = ast.parse(annotation).body
-        if len(body) == 1 and type(body[0].value) is ast.Constant:  # type: ignore[attr-defined]
-            if type(body[0].value.value) is not str:  # type: ignore[attr-defined]
-                raise_value_error()
-            return body[0].value.value  # type: ignore[attr-defined]
-    except SyntaxError:
-        pass
+        # If it looks like a dbus signature, return it directly. These are sorted
+        # in the order of the "Summary of types" table in the D-Bus spec to make
+        # verification easier.
+        if re.match(r'^[ybnqiuxtdsoga\(\)v\{\}h]+$', annotation):
+            return annotation
 
-    return annotation
+        # Otherwise, assume deferred evaluation of annotations.
+
+        try:
+            # It could be a string literal, e.g "'s'", in which case this will
+            # effectively strip the quotes. Other literals would pass here, but
+            # they aren't expected, so we just let those fail later.
+            return ast.literal_eval(annotation)
+        except ValueError:
+            # Anything that isn't a Python literal will raise ValueError.
+            pass
+
+        # Deferred evaluation of annotations, so evaluate it now.
+        annotation = eval(annotation, module.__dict__, {})
+
+
+    if get_origin(annotation) is Annotated:
+        try:
+            sig = next(s for s in get_args(annotation) if type(s) is DBusSignature)
+        except StopIteration:
+            raise ValueError(
+                f"Annotated D-Bus type must include a DBusSignature annotation (got {annotation:!r})"
+            )
+        return sig.signature
+
+    raise ValueError(
+        f"D-Bus signature annotations must be a string constant or typing.Annotated with DBusSignature (got {annotation!r})"
+    )
 
 
 def _replace_fds(

--- a/src/dbus_fast/_private/util.py
+++ b/src/dbus_fast/_private/util.py
@@ -123,7 +123,7 @@ def parse_annotation(annotation: Any, module: Any) -> str:
         # If it looks like a dbus signature, return it directly. These are sorted
         # in the order of the "Summary of types" table in the D-Bus spec to make
         # verification easier.
-        if re.match(r'^[ybnqiuxtdsoga\(\)v\{\}h]+$', annotation):
+        if re.match(r"^[ybnqiuxtdsoga\(\)v\{\}h]+$", annotation):
             return annotation
 
         # Otherwise, assume deferred evaluation of annotations.
@@ -139,7 +139,6 @@ def parse_annotation(annotation: Any, module: Any) -> str:
 
         # Deferred evaluation of annotations, so evaluate it now.
         annotation = eval(annotation, module.__dict__, {})
-
 
     if get_origin(annotation) is Annotated:
         try:

--- a/src/dbus_fast/_private/util.py
+++ b/src/dbus_fast/_private/util.py
@@ -145,7 +145,7 @@ def parse_annotation(annotation: Any, module: Any) -> str:
             sig = next(s for s in get_args(annotation) if type(s) is DBusSignature)
         except StopIteration:
             raise ValueError(
-                f"Annotated D-Bus type must include a DBusSignature annotation (got {annotation:!r})"
+                f"Annotated D-Bus type must include a DBusSignature annotation (got {annotation!r})"
             )
         return sig.signature
 

--- a/src/dbus_fast/aio/proxy_object.py
+++ b/src/dbus_fast/aio/proxy_object.py
@@ -45,7 +45,7 @@ class ProxyInterface(BaseProxyInterface):
     DBus methods are exposed as coroutines that take arguments that correpond
     to the *in args* of the interface method definition and return a ``result``
     that corresponds to the *out arg*. If the method has more than one out arg,
-    they are returned within a :class:`list`.
+    they are returned within a :class:`tuple`.
 
     To *listen to a signal* use this form:
 

--- a/src/dbus_fast/annotations.py
+++ b/src/dbus_fast/annotations.py
@@ -61,9 +61,6 @@ class DBusSignature:
 
     signature: str
 
-    def __str__(self) -> str:
-        return self.signature
-
 
 DBusBool = Annotated[bool, DBusSignature("b")]
 """

--- a/src/dbus_fast/annotations.py
+++ b/src/dbus_fast/annotations.py
@@ -45,6 +45,7 @@ __all__ = [
     "DBusVariant",
 ]
 
+
 @dataclass(frozen=True, slots=True)
 class DBusSignature:
     """

--- a/src/dbus_fast/annotations.py
+++ b/src/dbus_fast/annotations.py
@@ -26,6 +26,7 @@ from dbus_fast.signature import Variant
 __all__ = [
     "DBusBool",
     "DBusByte",
+    "DBusBytes",
     "DBusDict",
     "DBusDouble",
     "DBusInt16",
@@ -37,6 +38,7 @@ __all__ = [
     "DBusUInt16",
     "DBusUInt32",
     "DBusUInt64",
+    "DBusUnixFd",
     "DBusVariant",
 ]
 

--- a/src/dbus_fast/annotations.py
+++ b/src/dbus_fast/annotations.py
@@ -1,24 +1,26 @@
 """
-The :mod:`dbus_fast.annotations` module contains type aliases that can be used in
-place of D-Bus signature strings in order to get proper Python type hints. This
-applies to methods decorated with :meth:`dbus_property <dbus_fast.service.dbus_property>`,
+The :mod:`dbus_fast.annotations` module contains :class:`DBusSignature` that
+can be used with :class:`typing.Annotated` to provide D-Bus signature annotations
+in a manner that is compatible with type hints. This applies to methods decorated
+with :meth:`dbus_property <dbus_fast.service.dbus_property>`,
 :meth:`dbus_method <dbus_fast.service.dbus_method>` or :meth:`dbus_signal
 <dbus_fast.service.dbus_signal>`.
 
-This module only includes common types. You can construct your own annotated
-types like this::
+The module also includes some type aliases for common D-Bus types. You can
+construct your own annotated types like this::
 
     from typing import Annotated
 
-    MyDBusStruct = Annotated[tuple[int, str], "(is)"]
+    MyDBusStruct = Annotated[tuple[int, str], DBusSignature("(is)")]
 
 Or you can use ``Annotated[...]`` directly without creating an alias.
 
-.. versionadded:: v3.2.0
+.. versionadded:: v4.0.0
     Prior to this version, annotations had to be specified as D-Bus signature
     strings.
 """
 
+from dataclasses import dataclass
 from typing import Annotated
 
 from dbus_fast.signature import Variant
@@ -34,6 +36,7 @@ __all__ = [
     "DBusInt64",
     "DBusObjectPath",
     "DBusSignature",
+    "DBusSignatureType",
     "DBusStr",
     "DBusUInt16",
     "DBusUInt32",
@@ -42,67 +45,89 @@ __all__ = [
     "DBusVariant",
 ]
 
-DBusBool = Annotated[bool, "b"]
+@dataclass(frozen=True, slots=True)
+class DBusSignature:
+    """
+    A D-Bus signature annotation.
+
+    This class is used to create D-Bus type annotations. For example::
+
+        from typing import Annotated
+        from dbus_fast.annotations import DBusSignature
+
+        MyDBusStruct = Annotated[tuple[int, str], DBusSignature("(is)")]
+    """
+
+    signature: str
+
+    def __str__(self) -> str:
+        return self.signature
+
+
+DBusBool = Annotated[bool, DBusSignature("b")]
 """
 D-Bus BOOLEAN type ("b").
 """
-DBusByte = Annotated[int, "y"]
+DBusByte = Annotated[int, DBusSignature("y")]
 """
 D-Bus BYTE type ("y").
 """
-DBusInt16 = Annotated[int, "n"]
+DBusInt16 = Annotated[int, DBusSignature("n")]
 """
 D-Bus INT16 type ("n").
 """
-DBusUInt16 = Annotated[int, "q"]
+DBusUInt16 = Annotated[int, DBusSignature("q")]
 """
 D-Bus UINT16 type ("q").
 """
-DBusInt32 = Annotated[int, "i"]
+DBusInt32 = Annotated[int, DBusSignature("i")]
 """
 D-Bus INT32 type ("i").
 """
-DBusUInt32 = Annotated[int, "u"]
+DBusUInt32 = Annotated[int, DBusSignature("u")]
 """
 D-Bus UINT32 type ("u").
 """
-DBusInt64 = Annotated[int, "x"]
+DBusInt64 = Annotated[int, DBusSignature("x")]
 """
 D-Bus INT64 type ("x").
 """
-DBusUInt64 = Annotated[int, "t"]
+DBusUInt64 = Annotated[int, DBusSignature("t")]
 """
 D-Bus UINT64 type ("t").
 """
-DBusDouble = Annotated[float, "d"]
+DBusDouble = Annotated[float, DBusSignature("d")]
 """
 D-Bus DOUBLE type ("d").
 """
-DBusStr = Annotated[str, "s"]
+DBusStr = Annotated[str, DBusSignature("s")]
 """
 D-Bus STRING type ("s").
 """
-DBusObjectPath = Annotated[str, "o"]
+DBusObjectPath = Annotated[str, DBusSignature("o")]
 """
 D-Bus OBJECT_PATH type ("o").
 """
-DBusSignature = Annotated[str, "g"]
+DBusSignatureType = Annotated[str, DBusSignature("g")]
 """
 D-Bus SIGNATURE type ("g").
+
+.. note:: This one doesn't follow the established naming convention since
+    "DBusSignature" is used for the annotation itself.)
 """
-DBusVariant = Annotated[Variant, "v"]
+DBusVariant = Annotated[Variant, DBusSignature("v")]
 """
 D-Bus VARIANT type ("v").
 """
-DBusDict = Annotated[dict[str, Variant], "a{sv}"]
+DBusDict = Annotated[dict[str, Variant], DBusSignature("a{sv}")]
 """
 D-Bus ARRAY of DICT_ENTRY type with STRING keys and VARIANT values ("a{sv}").
 """
-DBusUnixFd = Annotated[int, "h"]
+DBusUnixFd = Annotated[int, DBusSignature("h")]
 """
 D-Bus UNIX_FD type ("h").
 """
-DBusBytes = Annotated[bytes, "ay"]
+DBusBytes = Annotated[bytes, DBusSignature("ay")]
 """
 D-Bus ARRAY of BYTE type ("ay").
 """

--- a/src/dbus_fast/annotations.py
+++ b/src/dbus_fast/annotations.py
@@ -1,5 +1,5 @@
 """
-The :mod:`dbus_fast.annotated` module contains type aliases that can be used in
+The :mod:`dbus_fast.annotations` module contains type aliases that can be used in
 place of D-Bus signature strings in order to get proper Python type hints. This
 applies to methods decorated with :meth:`dbus_property <dbus_fast.service.dbus_property>`,
 :meth:`dbus_method <dbus_fast.service.dbus_method>` or :meth:`dbus_signal

--- a/src/dbus_fast/annotations.py
+++ b/src/dbus_fast/annotations.py
@@ -111,7 +111,7 @@ DBusSignatureType = Annotated[str, DBusSignature("g")]
 D-Bus SIGNATURE type ("g").
 
 .. note:: This one doesn't follow the established naming convention since
-    "DBusSignature" is used for the annotation itself.)
+    "DBusSignature" is used for the annotation itself.
 """
 DBusVariant = Annotated[Variant, DBusSignature("v")]
 """

--- a/src/dbus_fast/annotations.py
+++ b/src/dbus_fast/annotations.py
@@ -1,0 +1,106 @@
+"""
+The :mod:`dbus_fast.annotated` module contains type aliases that can be used in
+place of D-Bus signature strings in order to get proper Python type hints. This
+applies to methods decorated with :meth:`dbus_property <dbus_fast.service.dbus_property>`,
+:meth:`dbus_method <dbus_fast.service.dbus_method>` or :meth:`dbus_signal
+<dbus_fast.service.dbus_signal>`.
+
+This module only includes common types. You can construct your own annotated
+types like this::
+
+    from typing import Annotated
+
+    MyDBusStruct = Annotated[tuple[int, str], "(is)"]
+
+Or you can use ``Annotated[...]`` directly without creating an alias.
+
+.. versionadded:: v3.2.0
+    Prior to this version, annotations had to be specified as D-Bus signature
+    strings.
+"""
+
+from typing import Annotated
+
+from dbus_fast.signature import Variant
+
+__all__ = [
+    "DBusBool",
+    "DBusByte",
+    "DBusDict",
+    "DBusDouble",
+    "DBusInt16",
+    "DBusInt32",
+    "DBusInt64",
+    "DBusObjectPath",
+    "DBusSignature",
+    "DBusStr",
+    "DBusUInt16",
+    "DBusUInt32",
+    "DBusUInt64",
+    "DBusVariant",
+]
+
+DBusBool = Annotated[bool, "b"]
+"""
+D-Bus BOOLEAN type ("b").
+"""
+DBusByte = Annotated[int, "y"]
+"""
+D-Bus BYTE type ("y").
+"""
+DBusInt16 = Annotated[int, "n"]
+"""
+D-Bus INT16 type ("n").
+"""
+DBusUInt16 = Annotated[int, "q"]
+"""
+D-Bus UINT16 type ("q").
+"""
+DBusInt32 = Annotated[int, "i"]
+"""
+D-Bus INT32 type ("i").
+"""
+DBusUInt32 = Annotated[int, "u"]
+"""
+D-Bus UINT32 type ("u").
+"""
+DBusInt64 = Annotated[int, "x"]
+"""
+D-Bus INT64 type ("x").
+"""
+DBusUInt64 = Annotated[int, "t"]
+"""
+D-Bus UINT64 type ("t").
+"""
+DBusDouble = Annotated[float, "d"]
+"""
+D-Bus DOUBLE type ("d").
+"""
+DBusStr = Annotated[str, "s"]
+"""
+D-Bus STRING type ("s").
+"""
+DBusObjectPath = Annotated[str, "o"]
+"""
+D-Bus OBJECT_PATH type ("o").
+"""
+DBusSignature = Annotated[str, "g"]
+"""
+D-Bus SIGNATURE type ("g").
+"""
+DBusVariant = Annotated[Variant, "v"]
+"""
+D-Bus VARIANT type ("v").
+"""
+DBusDict = Annotated[dict[str, Variant], "a{sv}"]
+"""
+D-Bus ARRAY of DICT_ENTRY type with STRING keys and VARIANT values ("a{sv}").
+"""
+DBusUnixFd = Annotated[int, "h"]
+"""
+D-Bus UNIX_FD type ("h").
+"""
+DBusBytes = Annotated[bytes, "ay"]
+"""
+D-Bus ARRAY of BYTE type ("ay").
+"""

--- a/src/dbus_fast/glib/proxy_object.py
+++ b/src/dbus_fast/glib/proxy_object.py
@@ -56,8 +56,8 @@ class ProxyInterface(BaseProxyInterface):
 
     To *synchronously* call a method, use the ``call_[METHOD]_sync()`` form.
     The ``result`` corresponds to the *out arg* of the introspection method
-    definition. If the method has more than one otu arg, they are returned
-    within a :class:`list`.
+    definition. If the method has more than one out arg, they are returned
+    within a :class:`tuple`.
 
     To *listen to a signal* use this form:
 

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -123,7 +123,7 @@ def dbus_method(
     If you use Python annotations for type hints, you can use :class:`typing.Annotated`
     to specify the Python type and the D-Bus signature at the same time like this::
 
-        from dbus_fast.annotations import DBusStr, DBusUInt32
+        from dbus_fast.annotations import DBusSignature, DBusStr, DBusUInt32
 
         @dbus_method()
         def echo(self, val: DBusStr) -> DBusStr:
@@ -132,7 +132,7 @@ def dbus_method(
         @dbus_method()
         def echo_two(
             self, val1: DBusStr, val2: DBusUInt32
-        ) -> Annotated[tuple[str, int], "su"]:
+        ) -> Annotated[tuple[str, int], DBusSignature("su")]:
             return val1, val2
 
     .. versionchanged:: v4.0.0
@@ -233,7 +233,7 @@ def dbus_signal(
     If you use Python annotations for type hints, you can use :class:`typing.Annotated`
     to specify the Python type and the D-Bus signature at the same time like this::
 
-        from dbus_fast.annotations import DBusStr
+        from dbus_fast.annotations import DBusSignature, DBusStr
 
         @dbus_signal()
         def string_signal(self, val: str) -> DBusStr:
@@ -242,7 +242,7 @@ def dbus_signal(
         @dbus_signal()
         def two_strings_signal(
             self, val1: str, val2: str
-        ) -> Annotated[tuple[str, str], "ss"]:
+        ) -> Annotated[tuple[str, str], DBusSignature("ss")]:
             return val1, val2
 
     .. versionchanged:: v4.0.0
@@ -434,7 +434,7 @@ def _real_fn_result_to_body(
         is_tuple = result_type is tuple
         if not is_tuple and result_type is not list:
             raise SignatureBodyMismatchError(
-                "Expected signal to return a list or tuple of arguments"
+                "Expected method or signal handler to return a list or tuple of arguments"
             )
         # Convert tuple to list for D-Bus Message compatibility (Cython requires list type)
         final_result = list(result) if is_tuple else result

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -427,11 +427,13 @@ def _real_fn_result_to_body(
         final_result = [result]
     else:
         result_type = type(result)
-        if result_type is not list and result_type is not tuple:
+        is_tuple = result_type is tuple
+        if not is_tuple and result_type is not list:
             raise SignatureBodyMismatchError(
                 "Expected signal to return a list or tuple of arguments"
             )
-        final_result = result
+        # Convert tuple to list for D-Bus Message compatibility (Cython requires list type)
+        final_result = list(result) if is_tuple else result
 
     if out_len != len(final_result):
         raise SignatureBodyMismatchError(

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -97,7 +97,7 @@ def dbus_method(
     client and will conform to the dbus-fast type system. The parameters
     returned will be returned to the calling client and must conform to the
     dbus-fast type system. If multiple parameters are returned, they must be
-    contained within a :class:`list`.
+    contained within a :class:`tuple`.
 
     The decorated method may raise a :class:`DBusError <dbus_fast.DBusError>`
     to return an error to the client.
@@ -117,7 +117,7 @@ def dbus_method(
 
         @dbus_method()
         def echo_two(self, val1: 's', val2: 'u') -> 'su':
-            return [val1, val2]
+            return val1, val2
 
     .. versionadded:: v2.46.0
         In older versions, this was named ``@method``. The old name still exists.
@@ -188,7 +188,7 @@ def dbus_signal(
     annotation with a signature string of a single complete DBus type and the
     return value of the class method must conform to the dbus-fast type system.
     If the signal has multiple out arguments, they must be returned within a
-    ``list``.
+    ``tuple``.
 
     :param name: The member name that will be used for this signal. Defaults to
         the name of the class method.
@@ -206,7 +206,7 @@ def dbus_signal(
 
         @dbus_signal()
         def two_strings_signal(self, val1, val2) -> 'ss':
-            return [val1, val2]
+            return val1, val2
 
     .. versionadded:: v2.46.0
         In older versions, this was named ``@signal``. The old name still exists.

--- a/src/dbus_fast/service.py
+++ b/src/dbus_fast/service.py
@@ -119,6 +119,26 @@ def dbus_method(
         def echo_two(self, val1: 's', val2: 'u') -> 'su':
             return val1, val2
 
+    If you use Python annotations for type hints, you can use :class:`typing.Annotated`
+    to specify the Python type and the D-Bus signature at the same time like this::
+
+        from dbus_fast.annotations import DBusStr, DBusUInt32
+
+        @dbus_method()
+        def echo(self, val: DBusStr) -> DBusStr:
+            return val
+
+        @dbus_method()
+        def echo_two(
+            self, val1: DBusStr, val2: DBusUInt32
+        ) -> Annotated[tuple[str, int], "su"]:
+            return val1, val2
+
+    .. versionchanged:: v3.2.0
+        :class:`typing.Annotated` can now be used to provide type hints and the
+        D-Bus signature at the same time. Older versions require D-Bus signature
+        strings to be used.
+
     .. versionadded:: v2.46.0
         In older versions, this was named ``@method``. The old name still exists.
     """
@@ -207,6 +227,26 @@ def dbus_signal(
         @dbus_signal()
         def two_strings_signal(self, val1, val2) -> 'ss':
             return val1, val2
+
+    If you use Python annotations for type hints, you can use :class:`typing.Annotated`
+    to specify the Python type and the D-Bus signature at the same time like this::
+
+        from dbus_fast.annotations import DBusStr
+
+        @dbus_signal()
+        def string_signal(self, val: str) -> DBusStr:
+            return val
+
+        @dbus_signal()
+        def two_strings_signal(
+            self, val1: str, val2: str
+        ) -> Annotated[tuple[str, str], "ss"]:
+            return val1, val2
+
+    .. versionchanged:: v3.2.0
+        :class:`typing.Annotated` can now be used to provide type hints and the
+        D-Bus signature at the same time. Older versions require D-Bus signature
+        strings to be used.
 
     .. versionadded:: v2.46.0
         In older versions, this was named ``@signal``. The old name still exists.
@@ -342,6 +382,24 @@ def dbus_property(
         @string_prop.setter
         def string_prop(self, val: 's'):
             self._string_prop = val
+
+    If you use Python annotations for type hints, you can use :class:`typing.Annotated`
+    to specify the Python type and the D-Bus signature at the same time like this::
+
+        from dbus_fast.annotations import DBusStr
+
+        @dbus_property()
+        def string_prop(self) -> DBusStr:
+            return self._string_prop
+
+        @string_prop.setter
+        def string_prop(self, val: DBusStr):
+            self._string_prop = val
+
+    .. versionchanged:: v3.2.0
+        :class:`typing.Annotated` can now be used to provide type hints and the
+        D-Bus signature at the same time. Older versions require D-Bus signature
+        strings to be used.
     """
     if type(access) is not PropertyAccess:
         raise TypeError("access must be a PropertyAccess class")

--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -195,36 +195,3 @@ def test_glib_proxy_object():
 
     bus.disconnect()
     bus2.disconnect()
-
-
-def test_bad_dbus_signature_annotation():
-    # Error message should tell the user how to fix it (use typing.Annotated with
-    # DBusSignature) and what they did wrong (used 'str').
-    with pytest.raises(
-        ValueError, match=r".*typing\.Annotated with DBusSignature.*<class 'str'>.*"
-    ):
-
-        class BadInterface(ServiceInterface):  # pyright: ignore[reportUnusedClass]
-            def __init__(self):
-                super().__init__("bad.interface")
-
-            @dbus_method()
-            def bad_method(self, what: str) -> str:
-                return what
-
-
-def test_bad_dbus_signature_annotation2():
-    # Error message should tell the user how to fix it (use DBusSignature) and
-    # what they did wrong (used typing.Annotated[...] without DBusSignature).
-    with pytest.raises(
-        ValueError,
-        match=r".*type must include a DBusSignature annotation.*typing.Annotated\[str, 's'\].*",
-    ):
-
-        class BadInterface(ServiceInterface):  # pyright: ignore[reportUnusedClass]
-            def __init__(self):
-                super().__init__("bad.interface")
-
-            @dbus_method()
-            def bad_method(self, what: Annotated[str, "s"]) -> Annotated[str, "s"]:
-                return what

--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -1,15 +1,19 @@
+# NOTE: Do not add `from __future__ import annotations` to this file. This file
+# provides coverage for the case where we don't have deferred evaluation of
+# annotations.
+
 import asyncio
 import logging
 import sys
 from logging.handlers import QueueHandler
 from queue import SimpleQueue
-from typing import Annotated
+from typing import Annotated, no_type_check
 
 import pytest
 
 import dbus_fast.introspection as intr
 from dbus_fast import DBusError, aio, glib
-from dbus_fast.annotations import DBusDict, DBusInt64, DBusStr
+from dbus_fast.annotations import DBusDict, DBusInt64, DBusSignature, DBusStr
 from dbus_fast.message import MessageFlag
 from dbus_fast.service import ServiceInterface, dbus_method
 from dbus_fast.signature import Variant
@@ -30,8 +34,10 @@ class ExampleInterface(ServiceInterface):
     def EchoInt64(self, what: DBusInt64) -> DBusInt64:
         return what
 
+    # This one intentionally keeps string-style annotations for coverage purposes.
+    @no_type_check
     @dbus_method()
-    def EchoString(self, what: DBusStr) -> DBusStr:
+    def EchoString(self, what: "s") -> "s":
         return what
 
     @dbus_method()
@@ -41,7 +47,7 @@ class ExampleInterface(ServiceInterface):
     @dbus_method()
     def EchoThree(
         self, what1: DBusStr, what2: DBusStr, what3: DBusStr
-    ) -> Annotated[tuple[str, str, str], "sss"]:
+    ) -> Annotated[tuple[str, str, str], DBusSignature("sss")]:
         return what1, what2, what3
 
     @dbus_method()

--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -196,11 +196,15 @@ def test_glib_proxy_object():
     bus.disconnect()
     bus2.disconnect()
 
+
 def test_bad_dbus_signature_annotation():
     # Error message should tell the user how to fix it (use typing.Annotated with
     # DBusSignature) and what they did wrong (used 'str').
-    with pytest.raises(ValueError, match=r".*typing\.Annotated with DBusSignature.*<class 'str'>.*"):
-        class BadInterface(ServiceInterface): # pyright: ignore[reportUnusedClass]
+    with pytest.raises(
+        ValueError, match=r".*typing\.Annotated with DBusSignature.*<class 'str'>.*"
+    ):
+
+        class BadInterface(ServiceInterface):  # pyright: ignore[reportUnusedClass]
             def __init__(self):
                 super().__init__("bad.interface")
 
@@ -208,11 +212,16 @@ def test_bad_dbus_signature_annotation():
             def bad_method(self, what: str) -> str:
                 return what
 
+
 def test_bad_dbus_signature_annotation2():
     # Error message should tell the user how to fix it (use DBusSignature) and
     # what they did wrong (used typing.Annotated[...] without DBusSignature).
-    with pytest.raises(ValueError, match=r".*type must include a DBusSignature annotation.*typing.Annotated\[str, 's'\].*"):
-        class BadInterface(ServiceInterface): # pyright: ignore[reportUnusedClass]
+    with pytest.raises(
+        ValueError,
+        match=r".*type must include a DBusSignature annotation.*typing.Annotated\[str, 's'\].*",
+    ):
+
+        class BadInterface(ServiceInterface):  # pyright: ignore[reportUnusedClass]
             def __init__(self):
                 super().__init__("bad.interface")
 

--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -38,7 +38,7 @@ class ExampleInterface(ServiceInterface):
 
     @dbus_method()
     def EchoThree(self, what1: "s", what2: "s", what3: "s") -> "sss":
-        return [what1, what2, what3]
+        return what1, what2, what3
 
     @dbus_method()
     def GetComplex(self) -> "a{sv}":  # noqa: F722

--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -3,11 +3,13 @@ import logging
 import sys
 from logging.handlers import QueueHandler
 from queue import SimpleQueue
+from typing import Annotated
 
 import pytest
 
 import dbus_fast.introspection as intr
 from dbus_fast import DBusError, aio, glib
+from dbus_fast.annotations import DBusDict, DBusInt64, DBusStr
 from dbus_fast.message import MessageFlag
 from dbus_fast.service import ServiceInterface, dbus_method
 from dbus_fast.signature import Variant
@@ -25,23 +27,25 @@ class ExampleInterface(ServiceInterface):
         pass
 
     @dbus_method()
-    def EchoInt64(self, what: "x") -> "x":
+    def EchoInt64(self, what: DBusInt64) -> DBusInt64:
         return what
 
     @dbus_method()
-    def EchoString(self, what: "s") -> "s":
+    def EchoString(self, what: DBusStr) -> DBusStr:
         return what
 
     @dbus_method()
-    def ConcatStrings(self, what1: "s", what2: "s") -> "s":
+    def ConcatStrings(self, what1: DBusStr, what2: DBusStr) -> DBusStr:
         return what1 + what2
 
     @dbus_method()
-    def EchoThree(self, what1: "s", what2: "s", what3: "s") -> "sss":
+    def EchoThree(
+        self, what1: DBusStr, what2: DBusStr, what3: DBusStr
+    ) -> Annotated[tuple[str, str, str], "sss"]:
         return what1, what2, what3
 
     @dbus_method()
-    def GetComplex(self) -> "a{sv}":  # noqa: F722
+    def GetComplex(self) -> DBusDict:
         """Return complex output."""
         return {"hello": Variant("s", "world")}
 

--- a/tests/client/test_methods.py
+++ b/tests/client/test_methods.py
@@ -195,3 +195,27 @@ def test_glib_proxy_object():
 
     bus.disconnect()
     bus2.disconnect()
+
+def test_bad_dbus_signature_annotation():
+    # Error message should tell the user how to fix it (use typing.Annotated with
+    # DBusSignature) and what they did wrong (used 'str').
+    with pytest.raises(ValueError, match=r".*typing\.Annotated with DBusSignature.*<class 'str'>.*"):
+        class BadInterface(ServiceInterface): # pyright: ignore[reportUnusedClass]
+            def __init__(self):
+                super().__init__("bad.interface")
+
+            @dbus_method()
+            def bad_method(self, what: str) -> str:
+                return what
+
+def test_bad_dbus_signature_annotation2():
+    # Error message should tell the user how to fix it (use DBusSignature) and
+    # what they did wrong (used typing.Annotated[...] without DBusSignature).
+    with pytest.raises(ValueError, match=r".*type must include a DBusSignature annotation.*typing.Annotated\[str, 's'\].*"):
+        class BadInterface(ServiceInterface): # pyright: ignore[reportUnusedClass]
+            def __init__(self):
+                super().__init__("bad.interface")
+
+            @dbus_method()
+            def bad_method(self, what: Annotated[str, "s"]) -> Annotated[str, "s"]:
+                return what

--- a/tests/client/test_properties.py
+++ b/tests/client/test_properties.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 from dbus_fast import DBusError, Message, aio, glib
+from dbus_fast.annotations import DBusDict, DBusInt64, DBusStr
 from dbus_fast.service import PropertyAccess, ServiceInterface, dbus_property
 from dbus_fast.signature import Variant
 from tests.util import check_gi_repository, skip_reason_no_gi
@@ -20,28 +21,28 @@ class ExampleInterface(ServiceInterface):
         self._int64_property = -10000
 
     @dbus_property()
-    def SomeProperty(self) -> "s":
+    def SomeProperty(self) -> DBusStr:
         return self._some_property
 
     @SomeProperty.setter
-    def SomeProperty(self, val: "s"):
+    def SomeProperty(self, val: DBusStr) -> None:
         self._some_property = val
 
     @dbus_property(access=PropertyAccess.READ)
-    def Int64Property(self) -> "x":
+    def Int64Property(self) -> DBusInt64:
         return self._int64_property
 
     @dbus_property(access=PropertyAccess.READ)
-    def ComplexProperty(self) -> "a{sv}":  # noqa: F722
+    def ComplexProperty(self) -> DBusDict:
         """Return complex output."""
         return {"hello": Variant("s", "world")}
 
     @dbus_property()
-    def ErrorThrowingProperty(self) -> "s":
+    def ErrorThrowingProperty(self) -> DBusStr:
         raise DBusError(self.error_name, self.error_text)
 
     @ErrorThrowingProperty.setter
-    def ErrorThrowingProperty(self, val: "s"):
+    def ErrorThrowingProperty(self, val: DBusStr) -> None:
         raise DBusError(self.error_name, self.error_text)
 
 

--- a/tests/client/test_signals.py
+++ b/tests/client/test_signals.py
@@ -21,7 +21,7 @@ class ExampleInterface(ServiceInterface):
         return "hello"
 
     @dbus_signal()
-    def SignalMultiple(self) -> Annotated[tuple[str, str],  DBusSignature("ss")]:
+    def SignalMultiple(self) -> Annotated[tuple[str, str], DBusSignature("ss")]:
         return "hello", "world"
 
     @dbus_signal()

--- a/tests/client/test_signals.py
+++ b/tests/client/test_signals.py
@@ -1,9 +1,11 @@
 import asyncio
+from typing import Annotated
 
 import pytest
 
 from dbus_fast import Message
 from dbus_fast.aio import MessageBus
+from dbus_fast.annotations import DBusDict, DBusStr
 from dbus_fast.constants import RequestNameReply
 from dbus_fast.introspection import Node
 from dbus_fast.service import ServiceInterface, dbus_signal
@@ -15,15 +17,15 @@ class ExampleInterface(ServiceInterface):
         super().__init__("test.interface")
 
     @dbus_signal()
-    def SomeSignal(self) -> "s":
+    def SomeSignal(self) -> DBusStr:
         return "hello"
 
     @dbus_signal()
-    def SignalMultiple(self) -> "ss":
-        return ["hello", "world"]
+    def SignalMultiple(self) -> Annotated[tuple[str, str], "ss"]:
+        return "hello", "world"
 
     @dbus_signal()
-    def SignalComplex(self) -> "a{sv}":  # noqa: F722
+    def SignalComplex(self) -> DBusDict:
         """Broadcast a complex signal."""
         return {"hello": Variant("s", "world")}
 

--- a/tests/client/test_signals.py
+++ b/tests/client/test_signals.py
@@ -5,7 +5,7 @@ import pytest
 
 from dbus_fast import Message
 from dbus_fast.aio import MessageBus
-from dbus_fast.annotations import DBusDict, DBusStr
+from dbus_fast.annotations import DBusDict, DBusSignature, DBusStr
 from dbus_fast.constants import RequestNameReply
 from dbus_fast.introspection import Node
 from dbus_fast.service import ServiceInterface, dbus_signal
@@ -21,7 +21,7 @@ class ExampleInterface(ServiceInterface):
         return "hello"
 
     @dbus_signal()
-    def SignalMultiple(self) -> Annotated[tuple[str, str], "ss"]:
+    def SignalMultiple(self) -> Annotated[tuple[str, str],  DBusSignature("ss")]:
         return "hello", "world"
 
     @dbus_signal()

--- a/tests/service/test_decorators.py
+++ b/tests/service/test_decorators.py
@@ -32,7 +32,9 @@ class ExampleInterface(ServiceInterface):
         return ["result"]
 
     @dbus_signal(name="renamed_signal", disabled=True)
-    def another_signal(self) -> Annotated[tuple[float, str, float, str], DBusSignature("(dodo)")]:
+    def another_signal(
+        self,
+    ) -> Annotated[tuple[float, str, float, str], DBusSignature("(dodo)")]:
         return (1, "/", 1, "/")
 
     @dbus_property(

--- a/tests/service/test_decorators.py
+++ b/tests/service/test_decorators.py
@@ -1,5 +1,8 @@
+from typing import Annotated
+
 from dbus_fast import PropertyAccess
 from dbus_fast import introspection as intr
+from dbus_fast.annotations import DBusObjectPath, DBusStr, DBusUInt32, DBusUInt64
 from dbus_fast.service import ServiceInterface, dbus_method, dbus_property, dbus_signal
 
 
@@ -11,43 +14,43 @@ class ExampleInterface(ServiceInterface):
         self._weird_prop = 500
 
     @dbus_method()
-    def some_method(self, one: "s", two: "s") -> "s":
+    def some_method(self, one: DBusStr, two: DBusStr) -> DBusStr:
         return "hello"
 
     @dbus_method(name="renamed_method", disabled=True)
-    def another_method(self, eight: "o", six: "t"):
+    def another_method(self, eight: DBusObjectPath, six: DBusUInt64) -> None:
         pass
 
     @dbus_signal()
-    def some_signal(self) -> "as":  # noqa: F722
+    def some_signal(self) -> Annotated[list[str], "as"]:
         return ["result"]
 
     @dbus_signal(name="renamed_signal", disabled=True)
-    def another_signal(self) -> "(dodo)":
+    def another_signal(self) -> Annotated[tuple[float, str, float, str], "(dodo)"]:
         return (1, "/", 1, "/")
 
     @dbus_property(
         name="renamed_readonly_property", access=PropertyAccess.READ, disabled=True
     )
-    def another_prop(self) -> "t":
+    def another_prop(self) -> DBusUInt64:
         return self._another_prop
 
     @dbus_property()
-    def some_prop(self) -> "u":
+    def some_prop(self) -> DBusUInt32:
         return self._some_prop
 
     @some_prop.setter
-    def some_prop(self, val: "u"):
+    def some_prop(self, val: DBusUInt32):
         self._some_prop = val + 1
 
     # for this one, the setter has a different name than the getter which is a
     # special case in the code
     @dbus_property()
-    def weird_prop(self) -> "t":
+    def weird_prop(self) -> DBusUInt64:
         return self._weird_prop
 
     @weird_prop.setter
-    def setter_for_weird_prop(self, val: "t"):
+    def setter_for_weird_prop(self, val: DBusUInt64) -> None:
         self._weird_prop = val
 
 

--- a/tests/service/test_decorators.py
+++ b/tests/service/test_decorators.py
@@ -24,7 +24,7 @@ class ExampleInterface(ServiceInterface):
 
     @dbus_signal(name="renamed_signal", disabled=True)
     def another_signal(self) -> "(dodo)":
-        return [1, "/", 1, "/"]
+        return (1, "/", 1, "/")
 
     @dbus_property(
         name="renamed_readonly_property", access=PropertyAccess.READ, disabled=True

--- a/tests/service/test_decorators.py
+++ b/tests/service/test_decorators.py
@@ -2,7 +2,13 @@ from typing import Annotated
 
 from dbus_fast import PropertyAccess
 from dbus_fast import introspection as intr
-from dbus_fast.annotations import DBusObjectPath, DBusStr, DBusUInt32, DBusUInt64
+from dbus_fast.annotations import (
+    DBusObjectPath,
+    DBusSignature,
+    DBusStr,
+    DBusUInt32,
+    DBusUInt64,
+)
 from dbus_fast.service import ServiceInterface, dbus_method, dbus_property, dbus_signal
 
 
@@ -22,11 +28,11 @@ class ExampleInterface(ServiceInterface):
         pass
 
     @dbus_signal()
-    def some_signal(self) -> Annotated[list[str], "as"]:
+    def some_signal(self) -> Annotated[list[str], DBusSignature("as")]:
         return ["result"]
 
     @dbus_signal(name="renamed_signal", disabled=True)
-    def another_signal(self) -> Annotated[tuple[float, str, float, str], "(dodo)"]:
+    def another_signal(self) -> Annotated[tuple[float, str, float, str], DBusSignature("(dodo)")]:
         return (1, "/", 1, "/")
 
     @dbus_property(

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -257,11 +257,15 @@ async def test_methods(interface_class):
     await asyncio.wait_for(bus1.wait_for_disconnect(), timeout=1)
     await asyncio.wait_for(bus2.wait_for_disconnect(), timeout=1)
 
+
 def test_bad_dbus_signature_annotation():
     # Error message should tell the user how to fix it (use typing.Annotated with
     # DBusSignature) and what they did wrong (used 'str').
-    with pytest.raises(ValueError, match=r".*typing\.Annotated with DBusSignature.*<class 'str'>.*"):
-        class BadInterface(ServiceInterface): # pyright: ignore[reportUnusedClass]
+    with pytest.raises(
+        ValueError, match=r".*typing\.Annotated with DBusSignature.*<class 'str'>.*"
+    ):
+
+        class BadInterface(ServiceInterface):  # pyright: ignore[reportUnusedClass]
             def __init__(self):
                 super().__init__("bad.interface")
 
@@ -269,11 +273,16 @@ def test_bad_dbus_signature_annotation():
             def bad_method(self, what: str) -> str:
                 return what
 
+
 def test_bad_dbus_signature_annotation2():
     # Error message should tell the user how to fix it (use DBusSignature) and
     # what they did wrong (used typing.Annotated[...] without DBusSignature).
-    with pytest.raises(ValueError, match=r".*type must include a DBusSignature annotation.*typing.Annotated\[str, 's'\].*"):
-        class BadInterface(ServiceInterface): # pyright: ignore[reportUnusedClass]
+    with pytest.raises(
+        ValueError,
+        match=r".*type must include a DBusSignature annotation.*typing.Annotated\[str, 's'\].*",
+    ):
+
+        class BadInterface(ServiceInterface):  # pyright: ignore[reportUnusedClass]
             def __init__(self):
                 super().__init__("bad.interface")
 

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -1,5 +1,9 @@
+# NOTE: This is not strictly needed, but included to get code coverage for
+# deferred evaluation of annotations. Do not remove this line.
+from __future__ import annotations
+
 import asyncio
-from typing import Annotated
+from typing import Annotated, no_type_check
 
 import pytest
 
@@ -13,7 +17,7 @@ from dbus_fast import (
     Variant,
 )
 from dbus_fast.aio import MessageBus
-from dbus_fast.annotations import DBusDict, DBusStr, DBusVariant
+from dbus_fast.annotations import DBusDict, DBusSignature, DBusStr, DBusVariant
 from dbus_fast.service import ServiceInterface, dbus_method
 
 
@@ -26,20 +30,22 @@ class ExampleInterface(ServiceInterface):
         assert type(self) is ExampleInterface
         return what
 
+    # This one intentionally keeps string-style annotations for coverage purposes.
+    @no_type_check
     @dbus_method()
     def echo_multiple(
-        self, what1: DBusStr, what2: DBusStr
-    ) -> Annotated[tuple[str, str], "ss"]:
+        self, what1: "s", what2: "s"  # noqa: UP037
+    ) -> "ss":  # noqa: UP037
         assert type(self) is ExampleInterface
         return what1, what2
 
     @dbus_method()
     def echo_containers(
         self,
-        array: Annotated[list[str], "as"],
+        array: Annotated[list[str], DBusSignature("as")],
         variant: DBusVariant,
-        dict_entries: Annotated[dict[str, Variant], "a{sv}"],
-        struct: Annotated[tuple[str, tuple[str, tuple[Variant]]], "(s(s(v)))"],
+        dict_entries: DBusDict,
+        struct: Annotated[tuple[str, tuple[str, tuple[Variant]]], DBusSignature("(s(s(v)))")],
     ) -> Annotated[
         tuple[
             list[str],
@@ -47,7 +53,7 @@ class ExampleInterface(ServiceInterface):
             dict[str, Variant],
             tuple[str, tuple[str, tuple[Variant]]],
         ],
-        "asva{sv}(s(s(v)))",
+        DBusSignature("asva{sv}(s(s(v)))"),
     ]:
         assert type(self) is ExampleInterface
         return array, variant, dict_entries, struct
@@ -87,17 +93,17 @@ class AsyncInterface(ServiceInterface):
     @dbus_method()
     async def echo_multiple(
         self, what1: DBusStr, what2: DBusStr
-    ) -> Annotated[tuple[str, str], "ss"]:
+    ) -> Annotated[tuple[str, str],  DBusSignature("ss")]:
         assert type(self) is AsyncInterface
         return what1, what2
 
     @dbus_method()
     async def echo_containers(
         self,
-        array: Annotated[list[str], "as"],
+        array: Annotated[list[str], DBusSignature("as")],
         variant: DBusVariant,
         dict_entries: DBusDict,
-        struct: Annotated[tuple[str, tuple[str, tuple[Variant]]], "(s(s(v)))"],
+        struct: Annotated[tuple[str, tuple[str, tuple[Variant]]], DBusSignature("(s(s(v)))")],
     ) -> Annotated[
         tuple[
             list[str],
@@ -105,7 +111,7 @@ class AsyncInterface(ServiceInterface):
             dict[str, Variant],
             tuple[str, tuple[str, tuple[Variant]]],
         ],
-        "asva{sv}(s(s(v)))",
+        DBusSignature("asva{sv}(s(s(v)))"),
     ]:
         assert type(self) is AsyncInterface
         return array, variant, dict_entries, struct

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -256,4 +256,3 @@ async def test_methods(interface_class):
     bus2.disconnect()
     await asyncio.wait_for(bus1.wait_for_disconnect(), timeout=1)
     await asyncio.wait_for(bus2.wait_for_disconnect(), timeout=1)
-

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -256,3 +256,27 @@ async def test_methods(interface_class):
     bus2.disconnect()
     await asyncio.wait_for(bus1.wait_for_disconnect(), timeout=1)
     await asyncio.wait_for(bus2.wait_for_disconnect(), timeout=1)
+
+def test_bad_dbus_signature_annotation():
+    # Error message should tell the user how to fix it (use typing.Annotated with
+    # DBusSignature) and what they did wrong (used 'str').
+    with pytest.raises(ValueError, match=r".*typing\.Annotated with DBusSignature.*<class 'str'>.*"):
+        class BadInterface(ServiceInterface): # pyright: ignore[reportUnusedClass]
+            def __init__(self):
+                super().__init__("bad.interface")
+
+            @dbus_method()
+            def bad_method(self, what: str) -> str:
+                return what
+
+def test_bad_dbus_signature_annotation2():
+    # Error message should tell the user how to fix it (use DBusSignature) and
+    # what they did wrong (used typing.Annotated[...] without DBusSignature).
+    with pytest.raises(ValueError, match=r".*type must include a DBusSignature annotation.*typing.Annotated\[str, 's'\].*"):
+        class BadInterface(ServiceInterface): # pyright: ignore[reportUnusedClass]
+            def __init__(self):
+                super().__init__("bad.interface")
+
+            @dbus_method()
+            def bad_method(self, what: Annotated[str, "s"]) -> Annotated[str, "s"]:
+                return what

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -33,7 +33,7 @@ class ExampleInterface(ServiceInterface):
     # This one intentionally keeps string-style annotations for coverage purposes.
     @no_type_check
     @dbus_method()
-    def echo_multiple(self, what1: "s", what2: "s") -> "ss":  # noqa: UP037
+    def echo_multiple(self, what1: s, what2: s) -> ss:
         assert type(self) is ExampleInterface
         return what1, what2
 

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -33,7 +33,7 @@ class ExampleInterface(ServiceInterface):
     # This one intentionally keeps string-style annotations for coverage purposes.
     @no_type_check
     @dbus_method()
-    def echo_multiple(self, what1: s, what2: s) -> ss:
+    def echo_multiple(self, what1: "s", what2: "s") -> "ss":  # noqa: UP037
         assert type(self) is ExampleInterface
         return what1, what2
 

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -257,35 +257,3 @@ async def test_methods(interface_class):
     await asyncio.wait_for(bus1.wait_for_disconnect(), timeout=1)
     await asyncio.wait_for(bus2.wait_for_disconnect(), timeout=1)
 
-
-def test_bad_dbus_signature_annotation():
-    # Error message should tell the user how to fix it (use typing.Annotated with
-    # DBusSignature) and what they did wrong (used 'str').
-    with pytest.raises(
-        ValueError, match=r".*typing\.Annotated with DBusSignature.*<class 'str'>.*"
-    ):
-
-        class BadInterface(ServiceInterface):  # pyright: ignore[reportUnusedClass]
-            def __init__(self):
-                super().__init__("bad.interface")
-
-            @dbus_method()
-            def bad_method(self, what: str) -> str:
-                return what
-
-
-def test_bad_dbus_signature_annotation2():
-    # Error message should tell the user how to fix it (use DBusSignature) and
-    # what they did wrong (used typing.Annotated[...] without DBusSignature).
-    with pytest.raises(
-        ValueError,
-        match=r".*type must include a DBusSignature annotation.*typing.Annotated\[str, 's'\].*",
-    ):
-
-        class BadInterface(ServiceInterface):  # pyright: ignore[reportUnusedClass]
-            def __init__(self):
-                super().__init__("bad.interface")
-
-            @dbus_method()
-            def bad_method(self, what: Annotated[str, "s"]) -> Annotated[str, "s"]:
-                return what

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -33,9 +33,7 @@ class ExampleInterface(ServiceInterface):
     # This one intentionally keeps string-style annotations for coverage purposes.
     @no_type_check
     @dbus_method()
-    def echo_multiple(
-        self, what1: "s", what2: "s"  # noqa: UP037
-    ) -> "ss":  # noqa: UP037
+    def echo_multiple(self, what1: s, what2: s) -> ss:
         assert type(self) is ExampleInterface
         return what1, what2
 
@@ -45,7 +43,9 @@ class ExampleInterface(ServiceInterface):
         array: Annotated[list[str], DBusSignature("as")],
         variant: DBusVariant,
         dict_entries: DBusDict,
-        struct: Annotated[tuple[str, tuple[str, tuple[Variant]]], DBusSignature("(s(s(v)))")],
+        struct: Annotated[
+            tuple[str, tuple[str, tuple[Variant]]], DBusSignature("(s(s(v)))")
+        ],
     ) -> Annotated[
         tuple[
             list[str],
@@ -93,7 +93,7 @@ class AsyncInterface(ServiceInterface):
     @dbus_method()
     async def echo_multiple(
         self, what1: DBusStr, what2: DBusStr
-    ) -> Annotated[tuple[str, str],  DBusSignature("ss")]:
+    ) -> Annotated[tuple[str, str], DBusSignature("ss")]:
         assert type(self) is AsyncInterface
         return what1, what2
 
@@ -103,7 +103,9 @@ class AsyncInterface(ServiceInterface):
         array: Annotated[list[str], DBusSignature("as")],
         variant: DBusVariant,
         dict_entries: DBusDict,
-        struct: Annotated[tuple[str, tuple[str, tuple[Variant]]], DBusSignature("(s(s(v)))")],
+        struct: Annotated[
+            tuple[str, tuple[str, tuple[Variant]]], DBusSignature("(s(s(v)))")
+        ],
     ) -> Annotated[
         tuple[
             list[str],

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Annotated
 
 import pytest
 
@@ -12,33 +13,44 @@ from dbus_fast import (
     Variant,
 )
 from dbus_fast.aio import MessageBus
+from dbus_fast.annotations import DBusDict, DBusStr, DBusVariant
 from dbus_fast.service import ServiceInterface, dbus_method
 
 
 class ExampleInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
 
     @dbus_method()
-    def echo(self, what: "s") -> "s":
+    def echo(self, what: DBusStr) -> DBusStr:
         assert type(self) is ExampleInterface
         return what
 
     @dbus_method()
-    def echo_multiple(self, what1: "s", what2: "s") -> "ss":
+    def echo_multiple(
+        self, what1: DBusStr, what2: DBusStr
+    ) -> Annotated[tuple[str, str], "ss"]:
         assert type(self) is ExampleInterface
         return what1, what2
 
     @dbus_method()
     def echo_containers(
         self,
-        array: "as",  # noqa: F722
-        variant: "v",
-        dict_entries: "a{sv}",  # noqa: F722
-        struct: "(s(s(v)))",
-    ) -> "asva{sv}(s(s(v)))":  # noqa: F722
+        array: Annotated[list[str], "as"],
+        variant: DBusVariant,
+        dict_entries: Annotated[dict[str, Variant], "a{sv}"],
+        struct: Annotated[tuple[str, tuple[str, tuple[Variant]]], "(s(s(v)))"],
+    ) -> Annotated[
+        tuple[
+            list[str],
+            Variant,
+            dict[str, Variant],
+            tuple[str, tuple[str, tuple[Variant]]],
+        ],
+        "asva{sv}(s(s(v)))",
+    ]:
         assert type(self) is ExampleInterface
-        return [array, variant, dict_entries, struct]
+        return array, variant, dict_entries, struct
 
     @dbus_method()
     def ping(self):
@@ -64,29 +76,39 @@ class ExampleInterface(ServiceInterface):
 
 
 class AsyncInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
 
     @dbus_method()
-    async def echo(self, what: "s") -> "s":
+    async def echo(self, what: DBusStr) -> DBusStr:
         assert type(self) is AsyncInterface
         return what
 
     @dbus_method()
-    async def echo_multiple(self, what1: "s", what2: "s") -> "ss":
+    async def echo_multiple(
+        self, what1: DBusStr, what2: DBusStr
+    ) -> Annotated[tuple[str, str], "ss"]:
         assert type(self) is AsyncInterface
         return what1, what2
 
     @dbus_method()
     async def echo_containers(
         self,
-        array: "as",  # noqa: F722
-        variant: "v",
-        dict_entries: "a{sv}",  # noqa: F722
-        struct: "(s(s(v)))",
-    ) -> "asva{sv}(s(s(v)))":  # noqa: F722
+        array: Annotated[list[str], "as"],
+        variant: DBusVariant,
+        dict_entries: DBusDict,
+        struct: Annotated[tuple[str, tuple[str, tuple[Variant]]], "(s(s(v)))"],
+    ) -> Annotated[
+        tuple[
+            list[str],
+            Variant,
+            dict[str, Variant],
+            tuple[str, tuple[str, tuple[Variant]]],
+        ],
+        "asva{sv}(s(s(v)))",
+    ]:
         assert type(self) is AsyncInterface
-        return [array, variant, dict_entries, struct]
+        return array, variant, dict_entries, struct
 
     @dbus_method()
     async def ping(self):

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -27,7 +27,7 @@ class ExampleInterface(ServiceInterface):
     @dbus_method()
     def echo_multiple(self, what1: "s", what2: "s") -> "ss":
         assert type(self) is ExampleInterface
-        return [what1, what2]
+        return what1, what2
 
     @dbus_method()
     def echo_containers(
@@ -75,7 +75,7 @@ class AsyncInterface(ServiceInterface):
     @dbus_method()
     async def echo_multiple(self, what1: "s", what2: "s") -> "ss":
         assert type(self) is AsyncInterface
-        return [what1, what2]
+        return what1, what2
 
     @dbus_method()
     async def echo_containers(

--- a/tests/service/test_properties.py
+++ b/tests/service/test_properties.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Annotated
 
 import pytest
 
@@ -11,11 +12,12 @@ from dbus_fast import (
     Variant,
 )
 from dbus_fast.aio import MessageBus
+from dbus_fast.annotations import DBusStr, DBusUInt64
 from dbus_fast.service import ServiceInterface, dbus_method, dbus_property
 
 
 class ExampleInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
         self._string_prop = "hi"
         self._readonly_prop = 100
@@ -24,52 +26,52 @@ class ExampleInterface(ServiceInterface):
         self._renamed_prop = "65"
 
     @dbus_property()
-    def string_prop(self) -> "s":
+    def string_prop(self) -> DBusStr:
         return self._string_prop
 
     @string_prop.setter
-    def string_prop_setter(self, val: "s"):
+    def string_prop_setter(self, val: DBusStr) -> None:
         self._string_prop = val
 
     @dbus_property(PropertyAccess.READ)
-    def readonly_prop(self) -> "t":
+    def readonly_prop(self) -> DBusUInt64:
         return self._readonly_prop
 
     @dbus_property()
-    def container_prop(self) -> "a(ss)":
+    def container_prop(self) -> Annotated[list[tuple[str, str]], "a(ss)"]:
         return self._container_prop
 
     @container_prop.setter
-    def container_prop(self, val: "a(ss)"):
+    def container_prop(self, val: Annotated[list[tuple[str, str]], "a(ss)"]):
         self._container_prop = val
 
     @dbus_property(name="renamed_prop")
-    def original_name(self) -> "s":
+    def original_name(self) -> DBusStr:
         return self._renamed_prop
 
     @original_name.setter
-    def original_name_setter(self, val: "s"):
+    def original_name_setter(self, val: DBusStr) -> None:
         self._renamed_prop = val
 
     @dbus_property(disabled=True)
-    def disabled_prop(self) -> "s":
+    def disabled_prop(self) -> DBusStr:
         return self._disabled_prop
 
     @disabled_prop.setter
-    def disabled_prop(self, val: "s"):
+    def disabled_prop(self, val: DBusStr) -> None:
         self._disabled_prop = val
 
     @dbus_property(disabled=True)
-    def throws_error(self) -> "s":
+    def throws_error(self) -> DBusStr:
         raise DBusError("test.error", "told you so")
 
     @throws_error.setter
-    def throws_error(self, val: "s"):
+    def throws_error(self, val: DBusStr) -> None:
         raise DBusError("test.error", "told you so")
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    def returns_wrong_type(self) -> "s":
-        return 5
+    def returns_wrong_type(self) -> DBusStr:
+        return 5  # type: ignore[return-value]
 
     @dbus_method()
     def do_emit_properties_changed(self):
@@ -79,7 +81,7 @@ class ExampleInterface(ServiceInterface):
 
 
 class AsyncInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
         self._string_prop = "hi"
         self._readonly_prop = 100
@@ -88,52 +90,52 @@ class AsyncInterface(ServiceInterface):
         self._renamed_prop = "65"
 
     @dbus_property()
-    async def string_prop(self) -> "s":
+    async def string_prop(self) -> DBusStr:
         return self._string_prop
 
     @string_prop.setter
-    async def string_prop_setter(self, val: "s"):
+    async def string_prop_setter(self, val: DBusStr) -> None:
         self._string_prop = val
 
     @dbus_property(PropertyAccess.READ)
-    async def readonly_prop(self) -> "t":
+    async def readonly_prop(self) -> DBusUInt64:
         return self._readonly_prop
 
     @dbus_property()
-    async def container_prop(self) -> "a(ss)":
+    async def container_prop(self) -> Annotated[list[tuple[str, str]], "a(ss)"]:
         return self._container_prop
 
     @container_prop.setter
-    async def container_prop(self, val: "a(ss)"):
+    async def container_prop(self, val: Annotated[list[tuple[str, str]], "a(ss)"]):
         self._container_prop = val
 
     @dbus_property(name="renamed_prop")
-    async def original_name(self) -> "s":
+    async def original_name(self) -> DBusStr:
         return self._renamed_prop
 
     @original_name.setter
-    async def original_name_setter(self, val: "s"):
+    async def original_name_setter(self, val: DBusStr) -> None:
         self._renamed_prop = val
 
     @dbus_property(disabled=True)
-    async def disabled_prop(self) -> "s":
+    async def disabled_prop(self) -> DBusStr:
         return self._disabled_prop
 
     @disabled_prop.setter
-    async def disabled_prop(self, val: "s"):
+    async def disabled_prop(self, val: DBusStr) -> None:
         self._disabled_prop = val
 
     @dbus_property(disabled=True)
-    async def throws_error(self) -> "s":
+    async def throws_error(self) -> DBusStr:
         raise DBusError("test.error", "told you so")
 
     @throws_error.setter
-    async def throws_error(self, val: "s"):
+    async def throws_error(self, val: DBusStr) -> None:
         raise DBusError("test.error", "told you so")
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    async def returns_wrong_type(self) -> "s":
-        return 5
+    async def returns_wrong_type(self) -> DBusStr:
+        return 5  # type: ignore[return-value]
 
     @dbus_method()
     def do_emit_properties_changed(self):

--- a/tests/service/test_properties.py
+++ b/tests/service/test_properties.py
@@ -18,6 +18,7 @@ from dbus_fast.service import ServiceInterface, dbus_method, dbus_property
 # Type alias since this is used multiple times in this file.
 TestDBusArrayOfStringTuple = Annotated[list[tuple[str, str]], DBusSignature("a(ss)")]
 
+
 class ExampleInterface(ServiceInterface):
     def __init__(self, name: str) -> None:
         super().__init__(name)

--- a/tests/service/test_properties.py
+++ b/tests/service/test_properties.py
@@ -12,9 +12,11 @@ from dbus_fast import (
     Variant,
 )
 from dbus_fast.aio import MessageBus
-from dbus_fast.annotations import DBusStr, DBusUInt64
+from dbus_fast.annotations import DBusSignature, DBusStr, DBusUInt64
 from dbus_fast.service import ServiceInterface, dbus_method, dbus_property
 
+# Type alias since this is used multiple times in this file.
+TestDBusArrayOfStringTuple = Annotated[list[tuple[str, str]], DBusSignature("a(ss)")]
 
 class ExampleInterface(ServiceInterface):
     def __init__(self, name: str) -> None:
@@ -38,11 +40,11 @@ class ExampleInterface(ServiceInterface):
         return self._readonly_prop
 
     @dbus_property()
-    def container_prop(self) -> Annotated[list[tuple[str, str]], "a(ss)"]:
+    def container_prop(self) -> TestDBusArrayOfStringTuple:
         return self._container_prop
 
     @container_prop.setter
-    def container_prop(self, val: Annotated[list[tuple[str, str]], "a(ss)"]):
+    def container_prop(self, val: TestDBusArrayOfStringTuple):
         self._container_prop = val
 
     @dbus_property(name="renamed_prop")
@@ -102,11 +104,11 @@ class AsyncInterface(ServiceInterface):
         return self._readonly_prop
 
     @dbus_property()
-    async def container_prop(self) -> Annotated[list[tuple[str, str]], "a(ss)"]:
+    async def container_prop(self) -> TestDBusArrayOfStringTuple:
         return self._container_prop
 
     @container_prop.setter
-    async def container_prop(self, val: Annotated[list[tuple[str, str]], "a(ss)"]):
+    async def container_prop(self, val: TestDBusArrayOfStringTuple):
         self._container_prop = val
 
     @dbus_property(name="renamed_prop")

--- a/tests/service/test_signals.py
+++ b/tests/service/test_signals.py
@@ -30,7 +30,7 @@ class ExampleInterface(ServiceInterface):
     @dbus_signal()
     def signal_multiple(self) -> "ss":
         assert type(self) is ExampleInterface
-        return ["hello", "world"]
+        return "hello", "world"
 
     @dbus_signal(name="renamed")
     def original_name(self):

--- a/tests/service/test_signals.py
+++ b/tests/service/test_signals.py
@@ -1,9 +1,11 @@
 import asyncio
+from typing import Annotated
 
 import pytest
 
 from dbus_fast import Message, MessageType
 from dbus_fast.aio import MessageBus
+from dbus_fast.annotations import DBusInt32, DBusStr
 from dbus_fast.constants import PropertyAccess
 from dbus_fast.service import (
     ServiceInterface,
@@ -15,7 +17,7 @@ from dbus_fast.signature import Variant
 
 
 class ExampleInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
 
     @dbus_signal()
@@ -23,12 +25,12 @@ class ExampleInterface(ServiceInterface):
         assert type(self) is ExampleInterface
 
     @dbus_signal()
-    def signal_simple(self) -> "s":
+    def signal_simple(self) -> DBusStr:
         assert type(self) is ExampleInterface
         return "hello"
 
     @dbus_signal()
-    def signal_multiple(self) -> "ss":
+    def signal_multiple(self) -> Annotated[tuple[str, str], "ss"]:
         assert type(self) is ExampleInterface
         return "hello", "world"
 
@@ -41,20 +43,20 @@ class ExampleInterface(ServiceInterface):
         assert type(self) is ExampleInterface
 
     @dbus_property(access=PropertyAccess.READ)
-    def test_prop(self) -> "i":
+    def test_prop(self) -> DBusInt32:
         return 42
 
 
 class SecondExampleInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
 
     @dbus_property(access=PropertyAccess.READ)
-    def str_prop(self) -> "s":
+    def str_prop(self) -> DBusStr:
         return "abc"
 
     @dbus_property(access=PropertyAccess.READ)
-    def list_prop(self) -> "ai":
+    def list_prop(self) -> Annotated[list[int], "ai"]:
         return [1, 2, 3]
 
 

--- a/tests/service/test_signals.py
+++ b/tests/service/test_signals.py
@@ -5,7 +5,7 @@ import pytest
 
 from dbus_fast import Message, MessageType
 from dbus_fast.aio import MessageBus
-from dbus_fast.annotations import DBusInt32, DBusStr
+from dbus_fast.annotations import DBusInt32, DBusSignature, DBusStr
 from dbus_fast.constants import PropertyAccess
 from dbus_fast.service import (
     ServiceInterface,
@@ -30,7 +30,7 @@ class ExampleInterface(ServiceInterface):
         return "hello"
 
     @dbus_signal()
-    def signal_multiple(self) -> Annotated[tuple[str, str], "ss"]:
+    def signal_multiple(self) -> Annotated[tuple[str, str], DBusSignature("ss")]:
         assert type(self) is ExampleInterface
         return "hello", "world"
 
@@ -56,7 +56,7 @@ class SecondExampleInterface(ServiceInterface):
         return "abc"
 
     @dbus_property(access=PropertyAccess.READ)
-    def list_prop(self) -> Annotated[list[int], "ai"]:
+    def list_prop(self) -> Annotated[list[int], DBusSignature("ai")]:
         return [1, 2, 3]
 
 

--- a/tests/service/test_standard_interfaces.py
+++ b/tests/service/test_standard_interfaces.py
@@ -5,6 +5,7 @@ import pytest
 from dbus_fast import Message, MessageType
 from dbus_fast import introspection as intr
 from dbus_fast.aio import MessageBus
+from dbus_fast.annotations import DBusByte, DBusStr
 from dbus_fast.constants import ErrorType
 from dbus_fast.service import PropertyAccess, ServiceInterface, dbus_property
 from dbus_fast.signature import Variant
@@ -13,27 +14,27 @@ standard_interfaces_count = len(intr.Node.default().interfaces)
 
 
 class ExampleInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__(name)
 
 
 class ExampleComplexInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self._foo = 42
         self._bar = "str"
         self._async_prop = "async"
         super().__init__(name)
 
     @dbus_property(access=PropertyAccess.READ)
-    def Foo(self) -> "y":
+    def Foo(self) -> DBusByte:
         return self._foo
 
     @dbus_property(access=PropertyAccess.READ)
-    def Bar(self) -> "s":
+    def Bar(self) -> DBusStr:
         return self._bar
 
     @dbus_property(access=PropertyAccess.READ)
-    async def AsyncProp(self) -> "s":
+    async def AsyncProp(self) -> DBusStr:
         return self._async_prop
 
 

--- a/tests/test_aio_multi_flags.py
+++ b/tests/test_aio_multi_flags.py
@@ -3,17 +3,18 @@ import asyncio
 import pytest
 
 from dbus_fast.aio import MessageBus
+from dbus_fast.annotations import DBusStr
 from dbus_fast.service import ServiceInterface, dbus_method
 
 
 @pytest.mark.asyncio
 async def test_multiple_flags_in_message():
     class ExampleInterface(ServiceInterface):
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             super().__init__(name)
 
         @dbus_method()
-        def Echo(self, what: "s") -> "s":
+        def Echo(self, what: DBusStr) -> DBusStr:
             return what
 
     bus = await MessageBus().connect()

--- a/tests/test_big_message.py
+++ b/tests/test_big_message.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 from dbus_fast import Message, MessageType, aio, glib
+from dbus_fast.annotations import DBusBytes
 from dbus_fast.service import ServiceInterface, dbus_method
 from tests.util import check_gi_repository, skip_reason_no_gi
 
@@ -15,7 +16,7 @@ class ExampleInterface(ServiceInterface):
         super().__init__("example.interface")
 
     @dbus_method()
-    def echo_bytes(self, what: "ay") -> "ay":
+    def echo_bytes(self, what: DBusBytes) -> DBusBytes:
         return what
 
 

--- a/tests/test_fd_passing.py
+++ b/tests/test_fd_passing.py
@@ -7,6 +7,7 @@ import pytest
 
 from dbus_fast import Message, MessageType
 from dbus_fast.aio import MessageBus
+from dbus_fast.annotations import DBusUnixFd
 from dbus_fast.service import ServiceInterface, dbus_method, dbus_property, dbus_signal
 from dbus_fast.signature import SignatureTree, Variant
 
@@ -23,44 +24,44 @@ def open_file_2():
 
 
 class ExampleInterface(ServiceInterface):
-    def __init__(self, name):
+    def __init__(self, name: str):
         super().__init__(name)
-        self.fds = []
+        self.fds: list[int] = []
 
     @dbus_method()
-    def ReturnsFd(self) -> "h":
+    def ReturnsFd(self) -> DBusUnixFd:
         fd = open_file()
         self.fds.append(fd)
         return fd
 
     @dbus_method()
-    def AcceptsFd(self, fd: "h"):
+    def AcceptsFd(self, fd: DBusUnixFd) -> None:
         assert fd != 0
         self.fds.append(fd)
 
-    def get_last_fd(self):
+    def get_last_fd(self) -> int:
         return self.fds[-1]
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         for fd in self.fds:
             os.close(fd)
         self.fds.clear()
 
     @dbus_signal()
-    def SignalFd(self) -> "h":
+    def SignalFd(self) -> DBusUnixFd:
         fd = open_file()
         self.fds.append(fd)
         return fd
 
     @dbus_property()
-    def PropFd(self) -> "h":
+    def PropFd(self) -> DBusUnixFd:
         if not self.fds:
             fd = open_file()
             self.fds.append(fd)
         return self.fds[-1]
 
     @PropFd.setter
-    def PropFd(self, fd: "h"):
+    def PropFd(self, fd: DBusUnixFd):
         assert fd
         self.fds.append(fd)
 


### PR DESCRIPTION
This is an alternative to #562.

I did not submit this yet because I got stuck on #551. But since there is another PR for the same thing, I'm posting it now to be able to compare.

Compared to #562 the user-facing change is the same but the implementation is different.

Differences to #562:
* The check for `Annotated` is a bit simpler. We just check for the `__metadata__` attribute.
* Includes documentation.
* Adds a `dbus_fast.annotations` module with type aliases for common types.
* Converts all tests to use annotated types.
* Lacks tests for checking error paths.