### PR TITLE
perf: replace _EMPTY_HEADERS.copy() with list literal in _header_fields

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -691,7 +691,7 @@ class Unmarshaller:
     def _header_fields(self, header_length: _int) -> list[Any]:
         """Header fields are always a(yv)."""
         beginning_pos = self._pos
-        headers = _EMPTY_HEADERS.copy()
+        headers = [None, None, None, None, None, None, None, None, None, None]
         if cython.compiled:
             if self._buf_len < self._pos + header_length:
                 raise IndexError("Not enough data to read header")


### PR DESCRIPTION
## Summary
- Replace `_EMPTY_HEADERS.copy()` with an inline list literal `[None, None, ...]` in `_header_fields`
- Avoids `.copy()` method call and attribute lookup overhead on every unmarshalled message

## Test plan
- [ ] Run `bench/unmarshall.py` and compare times
- [ ] Run existing test suite