### PR TITLE
perf: reuse bytearray buffer in _next_message instead of allocating

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -344,7 +344,7 @@ class Unmarshaller:
             self._unix_fds = []
         to_clear = HEADER_SIGNATURE_SIZE + self._msg_len
         if self._buf_len == to_clear:
-            self._buf = bytearray.__new__(bytearray)
+            del self._buf[:]
             self._buf_len = 0
         else:
             del self._buf[:to_clear]


### PR DESCRIPTION
## Summary
- Replace `self._buf = bytearray.__new__(bytearray)` with `del self._buf[:]` in `_next_message`
- Avoids allocating a new bytearray object on every fully-consumed message
- Keeps `_buf_ustr` reference in sync automatically since the underlying object is unchanged

## Test plan
- [ ] Run `bench/unmarshall.py` and compare times
- [ ] Run existing test suite