### PR TITLE
perf: reduce function call overhead in variant unmarshalling

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -205,6 +205,8 @@ cdef class Unmarshaller:
     @cython.locals(
         tree=SignatureTree,
         token_as_int=cython.uint,
+        signature_len=cython.uint,
+        o=cython.ulong,
         var=Variant,
     )
     cdef Variant _read_variant(self)

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -560,10 +560,10 @@ class Unmarshaller:
             if token_as_int == TOKEN_U_AS_INT:
                 return Variant._factory(SIGNATURE_TREE_U, self._read_uint32_unpack())
             if token_as_int == TOKEN_Y_AS_INT:
+                self._pos += 1
                 if cython.compiled:
                     if self._buf_len < self._pos:
                         raise IndexError("Not enough data to read byte")
-                self._pos += 1
                 return Variant._factory(SIGNATURE_TREE_Y, self._buf_ustr[self._pos - 1])
             # Uncommon single-byte type, decode for fallback
             signature = chr(token_as_int)

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -739,7 +739,7 @@ class Unmarshaller:
                 headers[field_0] = self._read_signature()
             elif token_as_int == TOKEN_U_AS_INT:
                 headers[field_0] = self._read_uint32_unpack()
-            else:
+            else:  # pragma: no cover
                 token = self._buf_ustr[o : o + signature_len].decode()
                 # There shouldn't be any other types in the header
                 # but just in case, we'll read it using the slow path

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -536,10 +536,19 @@ class Unmarshaller:
         return self._read_variant()
 
     def _read_variant(self) -> Variant:
-        signature = self._read_signature()
-        token_as_int = ord(signature[0])
+        # Inline signature reading to avoid _read_signature() call,
+        # .decode(), and ord() for the common single-byte case.
         # verify in Variant is only useful on construction not unmarshalling
-        if len(signature) == 1:
+        if cython.compiled:
+            if self._buf_len < self._pos:
+                raise IndexError("Not enough data to read signature")
+        signature_len = self._buf_ustr[self._pos]
+        if signature_len == 1:
+            token_as_int = self._buf_ustr[self._pos + 1]
+            self._pos += 3  # 1 len byte + 1 signature char + 1 null terminator
+            if cython.compiled:
+                if self._buf_len < self._pos:
+                    raise IndexError("Not enough data to read signature")
             if token_as_int == TOKEN_N_AS_INT:
                 return Variant._factory(SIGNATURE_TREE_N, self._read_int16_unpack())
             if token_as_int == TOKEN_S_AS_INT:
@@ -556,7 +565,17 @@ class Unmarshaller:
                         raise IndexError("Not enough data to read byte")
                 self._pos += 1
                 return Variant._factory(SIGNATURE_TREE_Y, self._buf_ustr[self._pos - 1])
-        elif token_as_int == TOKEN_A_AS_INT:
+            # Uncommon single-byte type, decode for fallback
+            signature = chr(token_as_int)
+        else:
+            o = self._pos + 1
+            self._pos = o + signature_len + 1
+            if cython.compiled:
+                if self._buf_len < self._pos:
+                    raise IndexError("Not enough data to read signature")
+            signature = self._buf_ustr[o : o + signature_len].decode()
+            token_as_int = self._buf_ustr[o]
+        if token_as_int == TOKEN_A_AS_INT:
             if signature == "ay":
                 return Variant._factory(
                     SIGNATURE_TREE_AY, self.read_array(SIGNATURE_TREE_AY_TYPES_0)
@@ -718,6 +737,8 @@ class Unmarshaller:
                 headers[field_0] = self._read_string_unpack()
             elif token_as_int == TOKEN_G_AS_INT:
                 headers[field_0] = self._read_signature()
+            elif token_as_int == TOKEN_U_AS_INT:
+                headers[field_0] = self._read_uint32_unpack()
             else:
                 token = self._buf_ustr[o : o + signature_len].decode()
                 # There shouldn't be any other types in the header

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -540,15 +540,15 @@ class Unmarshaller:
         # .decode(), and ord() for the common single-byte case.
         # verify in Variant is only useful on construction not unmarshalling
         if cython.compiled:
-            if self._buf_len < self._pos:
+            if self._buf_len <= self._pos:
                 raise IndexError("Not enough data to read signature")
         signature_len = self._buf_ustr[self._pos]
         if signature_len == 1:
-            token_as_int = self._buf_ustr[self._pos + 1]
             self._pos += 3  # 1 len byte + 1 signature char + 1 null terminator
             if cython.compiled:
                 if self._buf_len < self._pos:
                     raise IndexError("Not enough data to read signature")
+            token_as_int = self._buf_ustr[self._pos - 2]
             if token_as_int == TOKEN_N_AS_INT:
                 return Variant._factory(SIGNATURE_TREE_N, self._read_int16_unpack())
             if token_as_int == TOKEN_S_AS_INT:

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import struct
 from enum import Enum
 from typing import Any
 
@@ -916,3 +917,60 @@ def test_marshalling_struct_accepts_lists():
     marshalled = msg._marshall(False)
     unmarshalled_msg = Unmarshaller(io.BytesIO(marshalled)).unmarshall()
     assert unpack_variants(unmarshalled_msg.body)[0] == (RaucState.GOOD.value,)
+
+
+def _build_variant_message(variant: Variant) -> bytearray:
+    """Build a minimal METHOD_RETURN message with a single variant body."""
+    msg = Message(
+        message_type=MessageType.METHOD_RETURN,
+        reply_serial=1,
+        signature="v",
+        body=[variant],
+    )
+    return bytearray(msg._marshall(False))
+
+
+def _truncate_body(data: bytearray, body_bytes: int) -> bytearray:
+    """Truncate a message to keep only the first body_bytes of body data.
+
+    Adjusts the body_len header field to match.
+    """
+    header_len = struct.unpack_from("<I", data, 12)[0]
+    pad = (-header_len) & 7
+    body_start = 16 + header_len + pad
+    trunc = bytearray(data[: body_start + body_bytes])
+    struct.pack_into("<I", trunc, 4, body_bytes)
+    return trunc
+
+
+@pytest.mark.skipif(not is_compiled(), reason="requires cython for bounds checks")
+def test_read_variant_truncated_signature() -> None:
+    """Truncating after the signature length byte should raise IndexError."""
+    full = _build_variant_message(Variant("n", -89))
+    # Body is: 01 6e 00 <padding> <int16>
+    # Keep only 1 byte of body (just the signature_len byte)
+    trunc = _truncate_body(full, 1)
+    with pytest.raises(IndexError):
+        Unmarshaller(io.BytesIO(bytes(trunc))).unmarshall()
+
+
+@pytest.mark.skipif(not is_compiled(), reason="requires cython for bounds checks")
+def test_read_variant_truncated_signature_no_null() -> None:
+    """Truncating after the signature char but before null should raise."""
+    full = _build_variant_message(Variant("n", -89))
+    # Body is: 01 6e 00 <padding> <int16>
+    # Keep only 2 bytes (signature_len + signature char, no null terminator)
+    trunc = _truncate_body(full, 2)
+    with pytest.raises(IndexError):
+        Unmarshaller(io.BytesIO(bytes(trunc))).unmarshall()
+
+
+@pytest.mark.skipif(not is_compiled(), reason="requires cython for bounds checks")
+def test_read_variant_truncated_byte_value() -> None:
+    """A byte variant truncated before its value should raise IndexError."""
+    full = _build_variant_message(Variant("y", 42))
+    # Body is: 01 79 00 2a (sig_len, 'y', null, value)
+    # Keep only 3 bytes (signature complete, but no value byte)
+    trunc = _truncate_body(full, 3)
+    with pytest.raises(IndexError):
+        Unmarshaller(io.BytesIO(bytes(trunc))).unmarshall()


### PR DESCRIPTION
## Summary
- Inline signature reading directly into `_read_variant()` to avoid `_read_signature()` call, `.decode()`, and `ord()` for the common single-byte signature case. This eliminates three Python-level dispatches per variant read that show up as `Pyx_CyFunction_Vectorcall` overhead in profiles.
- Add a uint32 fast-path in `_header_fields()` to avoid dict lookup and Python function call for `reply_serial` header parsing.

## Context
Profiling `test_unmarshall_bluez_rssi_message` shows ~62% of time in `Pyx_CyFunction_Vectorcall FASTCALL_KEYWORDS` (Cython function call overhead) and ~26% in CPython internals. The actual data unpacking is cheap — the overhead is in Python-level method dispatch for `.decode()`, `ord()`, and function calls through object-typed pointers.

For single-byte variant signatures (the overwhelmingly common case for BluEZ messages like RSSI), we now read the signature byte directly from the C buffer pointer without creating a Python string, avoiding the decode/ord round-trip entirely.

## Test plan
- [x] Existing unmarshalling tests pass
- [x] CodSpeed benchmarks show improvement on `test_unmarshall_bluez_rssi_message`