### PR TITLE
perf: avoid Python truth test for reply_serial in _read_body

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -243,7 +243,8 @@ cdef class Unmarshaller:
         token_as_int="unsigned int",
         signature=str,
         tree=SignatureTree,
-        message=Message
+        message=Message,
+        reply_serial=object,
     )
     cdef void _read_body(self) except *
 

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -825,6 +825,7 @@ class Unmarshaller:
         flags = MESSAGE_FLAG_MAP.get(self._flag)
         if flags is None:
             flags = MESSAGE_FLAG_INTENUM(self._flag)
+        reply_serial = header_fields[HEADER_REPLY_SERIAL_IDX]
         message = Message.__new__(Message)
         message._fast_init(
             header_fields[HEADER_DESTINATION_IDX],
@@ -834,7 +835,7 @@ class Unmarshaller:
             MESSAGE_TYPE_MAP[self._message_type],
             flags,
             header_fields[HEADER_ERROR_NAME_IDX],
-            header_fields[HEADER_REPLY_SERIAL_IDX] or 0,
+            reply_serial if reply_serial is not None else 0,
             header_fields[HEADER_SENDER_IDX],
             self._unix_fds,
             tree,


### PR DESCRIPTION
## Summary
Replace `header_fields[HEADER_REPLY_SERIAL_IDX] or 0` with `reply_serial if reply_serial is not None else 0`.

## Generated C code comparison

**Before** (`or 0` → full Python truth test):
```c
__Pyx_GetItemInt_List(...)          // get from list
__Pyx_PyObject_IsTrue(...)          // PyObject_IsTrue → _PyObject_GetMethod
if (!truthy) { ... } else {
    __Pyx_PyLong_As_unsigned_int()  // convert to uint
}
```

**After** (`is not None` → C pointer comparison):
```c
(__pyx_v_reply_serial != Py_None)   // direct pointer compare
if (true) {
    __Pyx_PyLong_As_unsigned_int()  // convert to uint
} else { 0; }
```

## Notes
- Dropped the `list(_EMPTY_HEADERS)` change — `__Pyx_CallUnboundCMethod0` for `.copy()` caches the method lookup, making it faster than `PySequence_List` which goes through the full sequence protocol every call.

## Test plan
- [x] `test_marshaller.py` passes
- [ ] CodSpeed benchmarks