### PR TITLE
fix(bench): run benchmarks in tight loop for CodSpeed accuracy

### DIFF
--- a/tests/benchmarks/test_marshall.py
+++ b/tests/benchmarks/test_marshall.py
@@ -2,6 +2,8 @@ from pytest_codspeed import BenchmarkFixture
 
 from dbus_fast import Message
 
+ITERATIONS = 1000
+
 message = Message(
     destination="org.bluez",
     path="/",
@@ -13,6 +15,9 @@ message = Message(
 def test_marshall_bluez_get_managed_objects_message(
     benchmark: BenchmarkFixture,
 ) -> None:
+    _marshall = message._marshall
+
     @benchmark
-    def marhsall_bluez_get_managed_objects_message():
-        message._marshall(False)
+    def _():
+        for _ in range(ITERATIONS):
+            _marshall(False)

--- a/tests/benchmarks/test_unmarshall.py
+++ b/tests/benchmarks/test_unmarshall.py
@@ -108,9 +108,10 @@ def test_unmarshall_multiple_bluez_properties_message_socket(
 
     @benchmark
     def _():
-        send(bluez_properties_message)
-        for _ in range(MESSAGES_PER_CHUNK):
-            unmarshall()
+        for _ in range(ITERATIONS):
+            send(bluez_properties_message)
+            for _ in range(MESSAGES_PER_CHUNK):
+                unmarshall()
 
     sock1.close()
     sock2.close()

--- a/tests/benchmarks/test_unmarshall.py
+++ b/tests/benchmarks/test_unmarshall.py
@@ -5,27 +5,30 @@ from pytest_codspeed import BenchmarkFixture
 
 from dbus_fast._private.unmarshaller import Unmarshaller
 
+ITERATIONS = 1000
+
+bluez_rssi_message_bytes = bytes.fromhex(
+    "6c04010134000000e25389019500000001016f00250000002f6f72672f626c75657a2f686369302f6465"
+    "765f30385f33415f46325f31455f32425f3631000000020173001f0000006f72672e667265656465736b"
+    "746f702e444275732e50726f7065727469657300030173001100000050726f706572746965734368616e"
+    "67656400000000000000080167000873617b73767d617300000007017300040000003a312e3400000000"
+    "110000006f72672e626c75657a2e446576696365310000000e0000000000000004000000525353490001"
+    "6e00a7ff000000000000"
+)
+
 
 def test_unmarshall_bluez_rssi_message(benchmark: BenchmarkFixture) -> None:
-    bluez_rssi_message = (
-        "6c04010134000000e25389019500000001016f00250000002f6f72672f626c75657a2f686369302f6465"
-        "765f30385f33415f46325f31455f32425f3631000000020173001f0000006f72672e667265656465736b"
-        "746f702e444275732e50726f7065727469657300030173001100000050726f706572746965734368616e"
-        "67656400000000000000080167000873617b73767d617300000007017300040000003a312e3400000000"
-        "110000006f72672e626c75657a2e446576696365310000000e0000000000000004000000525353490001"
-        "6e00a7ff000000000000"
-    )
-
-    stream = io.BytesIO(bytes.fromhex(bluez_rssi_message))
+    stream = io.BytesIO(bluez_rssi_message_bytes * ITERATIONS)
 
     unmarshaller = Unmarshaller(stream)
     unmarshall = unmarshaller.unmarshall
     seek = stream.seek
 
     @benchmark
-    def unmarhsall_bluez_rssi_message():
+    def _():
         seek(0)
-        unmarshall()
+        for _ in range(ITERATIONS):
+            unmarshall()
 
 
 bluez_properties_message = (
@@ -59,33 +62,37 @@ bluez_properties_message = (
     b"\21\0\0\0org.bluez.Device1\0\0\0\16\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\306\377\0\0\0\0\0\0"
 )
 
+# 9 messages per chunk
+MESSAGES_PER_CHUNK = 9
+
 
 def test_unmarshall_bluez_properties_message(benchmark: BenchmarkFixture) -> None:
-    stream = io.BytesIO(bluez_properties_message)
+    stream = io.BytesIO(bluez_properties_message * ITERATIONS)
 
     unmarshaller = Unmarshaller(stream)
     unmarshall = unmarshaller.unmarshall
     seek = stream.seek
 
     @benchmark
-    def unmarshall_bluez_properties_message():
+    def _():
         seek(0)
-        unmarshall()
+        for _ in range(ITERATIONS):
+            unmarshall()
 
 
 def test_unmarshall_multiple_bluez_properties_message(
     benchmark: BenchmarkFixture,
 ) -> None:
-    stream = io.BytesIO(bluez_properties_message)
+    stream = io.BytesIO(bluez_properties_message * ITERATIONS)
 
     unmarshaller = Unmarshaller(stream)
     unmarshall = unmarshaller.unmarshall
     seek = stream.seek
 
     @benchmark
-    def unmarshall_bluez_properties_message():
+    def _():
         seek(0)
-        for _ in range(9):
+        for _ in range(ITERATIONS * MESSAGES_PER_CHUNK):
             unmarshall()
 
 
@@ -100,40 +107,43 @@ def test_unmarshall_multiple_bluez_properties_message_socket(
     send = sock2.send
 
     @benchmark
-    def unmarshall_bluez_properties_message():
+    def _():
         send(bluez_properties_message)
-        for _ in range(9):
+        for _ in range(MESSAGES_PER_CHUNK):
             unmarshall()
 
     sock1.close()
     sock2.close()
 
 
+bluez_interfaces_added_message = (
+    b'l\4\1\1\240\2\0\0\227\272\23\0u\0\0\0\1\1o\0\1\0\0\0/\0\0\0\0\0\0\0\2\1s\0"\0\0\0'
+    b"org.freedesktop.DBus.ObjectManager\0\0\0\0\0\0\3\1s\0\17\0\0\0InterfacesAdded\0\10"
+    b"\1g\0\noa{sa{sv}}\0\7\1s\0\4\0\0\0:1.4\0\0\0\0%\0\0\0/org/bluez/hci1/dev_58_2D_34"
+    b"_60_26_36\0\0\0p\2\0\0#\0\0\0org.freedesktop.DBus.Introspectable\0\0\0\0\0\0\0\0\0"
+    b"\21\0\0\0org.bluez.Device1\0\0\0\364\1\0\0\0\0\0\0\7\0\0\0Address\0\1s\0\0\21\0\0"
+    b"\00058:2D:34:60:26:36\0\0\0\v\0\0\0AddressType\0\1s\0\0\6\0\0\0public\0\0\4\0\0\0"
+    b"Name\0\1s\0\33\0\0\0Qingping Door/Window Sensor\0\0\0\0\0\5\0\0\0Alias\0\1s\0\0\0"
+    b"\0\33\0\0\0Qingping Door/Window Sensor\0\6\0\0\0Paired\0\1b\0\0\0\0\0\0\0\0\0\0\0"
+    b"\7\0\0\0Trusted\0\1b\0\0\0\0\0\0\0\0\0\0\7\0\0\0Blocked\0\1b\0\0\0\0\0\0\0\0\0\0\r"
+    b"\0\0\0LegacyPairing\0\1b\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\316\377\0\0\t"
+    b"\0\0\0Connected\0\1b\0\0\0\0\0\0\0\0\5\0\0\0UUIDs\0\2as\0\0\0\0\0\0\0\0\0\0\0\7\0"
+    b"\0\0Adapter\0\1o\0\0\17\0\0\0/org/bluez/hci1\0\0\0\0\0\v\0\0\0ServiceData\0\5a{sv}"
+    b"\0\0@\0\0\0\0\0\0\0$\0\0\0000000fe95-0000-1000-8000-00805f9b34fb\0\2ay\0\0\0\0\f\0"
+    b"\0\0000X\326\3\0026&`4-X\10\20\0\0\0ServicesResolved\0\1b\0\0\0\0\0\0\0\0\0\37\0\0"
+    b"\0org.freedesktop.DBus.Properties\0\0\0\0\0"
+)
+
+
 def test_unmarshall_bluez_interfaces_added_message(benchmark: BenchmarkFixture) -> None:
-    bluez_interfaces_added_message = (
-        b'l\4\1\1\240\2\0\0\227\272\23\0u\0\0\0\1\1o\0\1\0\0\0/\0\0\0\0\0\0\0\2\1s\0"\0\0\0'
-        b"org.freedesktop.DBus.ObjectManager\0\0\0\0\0\0\3\1s\0\17\0\0\0InterfacesAdded\0\10"
-        b"\1g\0\noa{sa{sv}}\0\7\1s\0\4\0\0\0:1.4\0\0\0\0%\0\0\0/org/bluez/hci1/dev_58_2D_34"
-        b"_60_26_36\0\0\0p\2\0\0#\0\0\0org.freedesktop.DBus.Introspectable\0\0\0\0\0\0\0\0\0"
-        b"\21\0\0\0org.bluez.Device1\0\0\0\364\1\0\0\0\0\0\0\7\0\0\0Address\0\1s\0\0\21\0\0"
-        b"\00058:2D:34:60:26:36\0\0\0\v\0\0\0AddressType\0\1s\0\0\6\0\0\0public\0\0\4\0\0\0"
-        b"Name\0\1s\0\33\0\0\0Qingping Door/Window Sensor\0\0\0\0\0\5\0\0\0Alias\0\1s\0\0\0"
-        b"\0\33\0\0\0Qingping Door/Window Sensor\0\6\0\0\0Paired\0\1b\0\0\0\0\0\0\0\0\0\0\0"
-        b"\7\0\0\0Trusted\0\1b\0\0\0\0\0\0\0\0\0\0\7\0\0\0Blocked\0\1b\0\0\0\0\0\0\0\0\0\0\r"
-        b"\0\0\0LegacyPairing\0\1b\0\0\0\0\0\0\0\0\0\0\0\0\4\0\0\0RSSI\0\1n\0\316\377\0\0\t"
-        b"\0\0\0Connected\0\1b\0\0\0\0\0\0\0\0\5\0\0\0UUIDs\0\2as\0\0\0\0\0\0\0\0\0\0\0\7\0"
-        b"\0\0Adapter\0\1o\0\0\17\0\0\0/org/bluez/hci1\0\0\0\0\0\v\0\0\0ServiceData\0\5a{sv}"
-        b"\0\0@\0\0\0\0\0\0\0$\0\0\0000000fe95-0000-1000-8000-00805f9b34fb\0\2ay\0\0\0\0\f\0"
-        b"\0\0000X\326\3\0026&`4-X\10\20\0\0\0ServicesResolved\0\1b\0\0\0\0\0\0\0\0\0\37\0\0"
-        b"\0org.freedesktop.DBus.Properties\0\0\0\0\0"
-    )
-    stream = io.BytesIO(bluez_interfaces_added_message)
+    stream = io.BytesIO(bluez_interfaces_added_message * ITERATIONS)
 
     unmarshaller = Unmarshaller(stream)
     unmarshall = unmarshaller.unmarshall
     seek = stream.seek
 
     @benchmark
-    def _unmarshall():
+    def _():
         seek(0)
-        unmarshall()
+        for _ in range(ITERATIONS):
+            unmarshall()


### PR DESCRIPTION
## Summary
- Run 1000 iterations per benchmark sample with 1000x duplicated message buffers so CodSpeed measures actual unmarshalling/marshalling time rather than per-iteration benchmark overhead
- Cache bound method for `message._marshall` in marshall benchmark
- Socket benchmark left at 9 messages per iteration (socketpair buffer limits)

## Context
Same approach as Bluetooth-Devices/ulid-transform#177. With a single iteration per sample, CodSpeed profiles are dominated by benchmark framework overhead (`_PyObject_GetMethod`, etc.) rather than the actual code under test.

## Test plan
- [x] Benchmark CI job passes
- [x] CodSpeed profiles show actual unmarshalling code dominating instead of framework overhead