### PR TITLE
docs: add CLAUDE.md and pr-workflow skill for LLM contributors

### DIFF
--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: pr-workflow
+description: Create pull requests for bluetooth-devices/dbus-fast. Use when creating PRs, submitting changes, or preparing contributions.
+allowed-tools: Read, Bash, Glob, Grep
+---
+
+# dbus-fast PR Workflow
+
+When creating a pull request for `bluetooth-devices/dbus-fast`,
+follow these steps. Repo-wide conventions live in
+[CLAUDE.md](../../../CLAUDE.md); this skill summarises the parts
+that matter at PR-creation time.
+
+## 1. Create branch from origin/main
+
+`origin` points at `bluetooth-devices/dbus-fast`; there is no fork
+in this workflow. Always re-fetch first so the branch is based on
+the latest `main`:
+
+```bash
+git fetch origin
+git checkout -b <branch-name> origin/main
+```
+
+## 2. Conventional Commits — for both commit subjects AND PR title
+
+Every commit subject and the PR title MUST follow
+[Conventional Commits](https://www.conventionalcommits.org/). Two
+separate CI gates check this:
+
+- **`commitlint`** (`ci.yml`) — runs
+  `@commitlint/config-conventional` over every commit on the
+  branch.
+- **`pr-title.yml`** — runs
+  `amannn/action-semantic-pull-request` over the PR title (which
+  GitHub uses as the squash-merge subject).
+
+Accepted types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`,
+`perf`, `refactor`, `revert`, `style`, `test`. Scope is optional.
+The subject (text after `type(scope):`) must start lowercase.
+Examples that pass both gates:
+
+```
+feat: add async context manager to MessageBus
+fix(unmarshaller): handle empty arrays at end of frame
+perf!: drop python 3.9 support
+```
+
+### Pick the type that matches the release impact
+
+`python-semantic-release` reads the commit log on `main` to decide
+the next version and write `CHANGELOG.md`:
+
+| Type                                                               | Release effect                                  |
+| ------------------------------------------------------------------ | ----------------------------------------------- |
+| `feat:`                                                            | minor bump, shows in changelog under Features   |
+| `fix:`, `perf:`                                                    | patch bump, shows under Bug Fixes / Performance |
+| any with `!` or `BREAKING CHANGE:` footer                          | major bump                                      |
+| `chore:`, `docs:`, `test:`, `ci:`, `style:`, `build:`, `refactor:` | no bump                                         |
+
+A user-visible bugfix tagged `chore:` will be silently omitted
+from the changelog; an internal refactor tagged `feat!:` will
+mint a fake major release. Pick the type a changelog reader would
+expect.
+
+## 3. There is no PR template
+
+The repo does not ship a `.github/PULL_REQUEST_TEMPLATE.md`, so
+the PR body is freeform. Write a short description of:
+
+- **What** the change does (one or two sentences of prose).
+- **Why** — the motivating bug, benchmark, or feature ask.
+- **Linked issues** — `fixes #N` / `closes #N` for issue
+  closure, or a bare reference if the change is related but
+  doesn't close.
+
+Keep it focused; the commit messages carry the per-commit detail.
+
+## 4. Commit hygiene
+
+- **Imperative-mood subject line** — "Add X", not "Added X".
+- **No `Co-Authored-By` trailers for LLM tools.** Project
+  preference — commits attribute the human who reviewed the
+  change.
+- Let pre-commit run (ruff lint + format, pyupgrade,
+  trailing-whitespace, etc.). If a hook auto-fixes a file, the
+  commit aborts — re-stage the auto-fixed files and re-commit.
+- Write tests for behavioural changes (under `tests/`). Run them
+  under `dbus-run-session` since the suite needs a session bus:
+
+  ```bash
+  dbus-run-session -- poetry run pytest --timeout=5
+  ```
+
+## 5. Push and create the PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create --repo bluetooth-devices/dbus-fast --base main \
+  --title "type(scope): lowercase subject under ~70 chars" \
+  --body-file /tmp/pr-body.md
+```
+
+Use `--body-file` rather than `--body "..."` so that backticks,
+asterisks, and other Markdown in the body are passed through
+verbatim instead of being mangled by shell quoting.
+
+The PR title is independently linted by `pr-title.yml` — if it
+fails the Conventional Commits check, the workflow blocks merge
+until the title is fixed. Fix it in the GitHub UI (or with
+`gh pr edit --title`); no push is needed.
+
+## 6. After the PR is open
+
+CI runs:
+
+- `lint` — pre-commit (ruff lint + format, pyupgrade,
+  trailing-whitespace).
+- `commitlint` — per-commit Conventional Commits check.
+- `pr-title` — PR-title Conventional Commits check.
+- `test` matrix — Python 3.10–3.14 + `3.14t`, each in both
+  `SKIP_CYTHON=1` and `REQUIRE_CYTHON=1` modes.
+- `test_big_endian` — s390x via `uraimo/run-on-arch-action`,
+  catches endian regressions in the marshaller/unmarshaller.
+- `benchmark` — CodSpeed run for the hot paths.
+
+A red `test_big_endian` job almost always means a byte-order
+assumption leaked into the marshaller/unmarshaller — re-check
+any `struct` format strings and endian conversions in
+`src/dbus_fast/_private/`. A CodSpeed regression on a Cythonized
+path is worth investigating before merge; if the regression is
+intentional, call it out in the PR body so reviewers don't have
+to guess.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,230 @@
+# Notes for LLM contributors
+
+A short orientation file for an LLM working in this repo. Skim
+before making changes; keep edits consistent with what's described
+here. Read [README.md](README.md) for the user-facing intro and
+[CONTRIBUTING.md](CONTRIBUTING.md) for the human contributor flow.
+
+## What this project is
+
+`dbus-fast` is a Python client/server library for
+[D-Bus](https://dbus.freedesktop.org/), targeting Linux desktop and
+mobile environments. It's a performance-focused fork of
+[`python-dbus-next`](https://github.com/altdesktop/python-dbus-next)
+and powers D-Bus-side integrations in
+[Home Assistant](https://www.home-assistant.io/) and the
+[bluetooth-devices](https://github.com/bluetooth-devices/) ecosystem
+(BlueZ, BleakDBus, etc.).
+
+Two IO backends are shipped from the same wire-level core:
+
+- `dbus_fast.aio` — asyncio (`MessageBus`, `MessageReader`,
+  `ProxyObject`). What most callers use.
+- `dbus_fast.glib` — GLib main-loop bindings, for GTK/GObject
+  callers.
+
+Hot paths are Cythonized at build time for throughput. They keep
+working as pure Python — `SKIP_CYTHON=1` disables the extension
+build — but production wheels ship compiled and CodSpeed
+benchmarks track that path. See _Build conventions_ below.
+
+## Code style
+
+- **Docstrings: terse, default to single-line.** A docstring is
+  the function's _contract_, not its narrative. Almost every
+  docstring should be one line — `"""Summary."""` — describing
+  what the function does and what the caller can pass. Multi-line
+  is the exception, only justified when there is non-obvious
+  caller-visible behaviour the type signature and parameter names
+  don't already convey.
+
+  **What does NOT belong in docstrings or comments:**
+  - Rationale / motivation / "why we used to do X" — that's the
+    PR description and the commit message. Git already remembers.
+  - Cross-references to issue numbers ("closes #N", "follow-up
+    to #M") — the PR body carries those.
+  - Restatement of the function body in prose. If the next line
+    of the docstring is just describing what the next line of
+    code does, delete the docstring line.
+  - Test docstrings retelling the production-side story. A test
+    docstring should name what the test pins, in one sentence —
+    not re-explain the bug, the fix, or the surrounding flow.
+
+- **Comments**: same bar. Default to writing no comments. Add
+  one only when the _why_ is non-obvious: a hidden constraint, a
+  subtle invariant, a workaround for a specific bug, behaviour
+  that would surprise a reader. If removing the comment wouldn't
+  confuse a future reader, don't write it.
+
+  **Don't remove existing comments** unless the code they
+  describe is gone — the original author left them for a reason.
+  Comments around Cython-specific patterns (`if cython.compiled:`,
+  branch hints, manual inlines) frequently exist _because_
+  removing them regressed a benchmark or broke the C build.
+
+- **Don't pad commits, docstrings, or comments with cross-
+  references** to old codepaths or issue numbers unless there's
+  a clear reason a future reader needs that link.
+
+- **Method order**: public API at the top, private helpers
+  (`_underscore_prefixed`) at the bottom.
+
+- **Line length**: 88 (ruff default with overrides — see
+  `pyproject.toml`). `python_requires = ">=3.10"`,
+  `target-version = "py310"` for ruff and `--py310-plus` for
+  pyupgrade. Don't introduce 3.11+-only syntax.
+
+- **Imports**: ruff/isort sorted (`profile = "black"`,
+  `known_first_party = ["dbus_fast", "tests"]`). Prefer absolute
+  imports rooted at `dbus_fast.*`.
+
+- **Generated artefacts are not checked in to source paths.**
+  Cython produces `*.c`, `*.html`, and `*.so` siblings of each
+  `.py` listed in `TO_CYTHONIZE`; `*.c` is excluded from the
+  wheel via `pyproject.toml`'s `exclude` list and `*.html` /
+  `*.so` are build outputs — don't commit them.
+
+## Commit / PR conventions
+
+- **Conventional Commits, lowercase subject.** The repo runs
+  `@commitlint/config-conventional` on every commit (via the
+  `commitlint` CI job and the `commitizen` pre-commit hook) and
+  `amannn/action-semantic-pull-request` on the PR title. Accepted
+  types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+  `refactor`, `revert`, `style`, `test`. Scopes are optional.
+  The subject (text after `type(scope):`) must start lowercase.
+  Examples that pass:
+  - `feat: add async context manager to MessageBus`
+  - `fix(unmarshaller): handle empty arrays at end of frame`
+  - `perf!: drop python 3.9 support`
+- **Releases are commit-driven.** `python-semantic-release` reads
+  the commit log on `main` to decide the next version and write
+  `CHANGELOG.md`. `feat:` → minor bump, `fix:`/`perf:` → patch
+  bump, anything with `!` or a `BREAKING CHANGE:` footer →
+  major. `chore:`, `docs:`, `test:`, `ci:`, `style:`, `build:`,
+  `refactor:` don't bump on their own. Pick the type that
+  reflects the actual user-visible effect — the changelog reader
+  is downstream.
+- **PR title becomes the squash subject.** GitHub uses the PR
+  title as the commit subject for "Squash and merge". The
+  `pr-title.yml` workflow enforces the same Conventional Commits
+  rules on the title, so a mis-formatted title can't sneak past
+  the per-commit linter. Title length isn't capped by commitlint
+  (`header-max-length` is disabled), but keep it readable —
+  under ~70 chars for the GitHub PR list, the body carries the
+  detail.
+- **No `Co-Authored-By` trailers for LLM authorship.** Project
+  preference: commits attribute the human who reviewed the
+  change, not the tool that produced the draft.
+- **No PR template.** The repo doesn't ship a
+  `.github/PULL_REQUEST_TEMPLATE.md`, so the body is freeform —
+  describe what the change does and why, link the issue if one
+  exists. The `pr-workflow` skill (under
+  `.claude/skills/pr-workflow/`) summarises this end-to-end.
+- **Pre-commit auto-fixes; re-stage.** `ruff --fix`, `ruff
+format`, `pyupgrade --py310-plus`, and the
+  `pre-commit-hooks` set (trailing-whitespace, end-of-file-fixer,
+  etc.) run on commit and will modify files in place. When a hook
+  rewrites a file, the commit aborts — re-stage the auto-fixed
+  files and commit again.
+
+## Running tests
+
+The full suite needs a session bus, so run it under
+`dbus-run-session`:
+
+```bash
+poetry install
+dbus-run-session -- poetry run pytest --timeout=5
+```
+
+CI runs the matrix across Python 3.10–3.14 plus `3.14t` (free-
+threaded), each in both `SKIP_CYTHON=1` and `REQUIRE_CYTHON=1`
+modes, on `ubuntu-latest`, with an additional `s390x` big-endian
+run via `uraimo/run-on-arch-action`. Tests must pass on every
+cell of that matrix; in particular, endian-sensitive code in the
+marshaller/unmarshaller is covered by the s390x leg.
+
+CodSpeed benchmarks live under `tests/benchmarks/` and
+`bench/` and run in CI on a separate path
+(`pytest-codspeed`). Don't regress them on the marshalling /
+unmarshalling hot paths without a deliberate trade-off in the PR
+body.
+
+## Build conventions
+
+- **Cython is optional but expected in wheels.** `build_ext.py`
+  cythonizes the modules listed in `TO_CYTHONIZE`
+  (`message.py`, `message_bus.py`, `service.py`, `signature.py`,
+  `unpack.py`, `_private/address.py`, `_private/marshaller.py`,
+  `_private/unmarshaller.py`, `aio/message_reader.py`). The
+  custom `BuildExt` swallows build failures so source installs
+  fall back to pure Python; CI wheel builds set
+  `REQUIRE_CYTHON=1` to make the build fail loudly if the
+  extension can't be produced. `SKIP_CYTHON=1` disables the
+  Cython step entirely (used by the pure-Python CI leg).
+- **`.pxd` discipline.** Modules that get Cythonized ship a
+  sibling `.pxd` for type declarations
+  (`message.pxd`, `message_bus.pxd`, `_private/unmarshaller.pxd`,
+  etc.). When changing the signature of a Cythonized function or
+  the layout of a Cythonized class, update the `.pxd` in the
+  same commit, or the extension build will pick up a stale
+  declaration and either fail to compile or — worse — silently
+  fall back to the slower Python path.
+- **`language_level = "3"`.** Set in `build_ext.py`'s `cythonize`
+  call. Don't introduce Python-2-compatible syntax.
+- **Free-threaded build target.** The matrix includes `3.14t`
+  (PEP 703). Anything added to `TO_CYTHONIZE` must stay free-
+  threading-safe — no module-level mutable globals, no
+  C-level shared state without a lock.
+- **`cython.compiled` guards.** Code that needs to differ
+  between the compiled and pure-Python paths uses
+  `if cython.compiled:` (see `_private/_cython_compat.py`).
+  The coverage config excludes those branches
+  (`exclude_also = ["if cython.compiled:"]`) — don't count their
+  absence in coverage as a missing test.
+
+## Useful entry points
+
+| Path                                     | What                                                             |
+| ---------------------------------------- | ---------------------------------------------------------------- |
+| `src/dbus_fast/aio/message_bus.py`       | High-level asyncio `MessageBus` — what most callers use          |
+| `src/dbus_fast/aio/message_reader.py`    | asyncio frame reader (Cythonized)                                |
+| `src/dbus_fast/aio/proxy_object.py`      | asyncio `ProxyObject` / `ProxyInterface`                         |
+| `src/dbus_fast/glib/`                    | GLib main-loop backend (`MessageBus`, `ProxyObject`)             |
+| `src/dbus_fast/message_bus.py`           | Wire-level `BaseMessageBus` shared by both backends (Cythonized) |
+| `src/dbus_fast/message.py`               | `Message` dataclass and serialisation entry point (Cythonized)   |
+| `src/dbus_fast/service.py`               | Service-side decorators and method dispatch (Cythonized)         |
+| `src/dbus_fast/signature.py`             | `SignatureTree`, `SignatureType`, `Variant` (Cythonized)         |
+| `src/dbus_fast/unpack.py`                | `unpack_variants` — fast variant flattening (Cythonized)         |
+| `src/dbus_fast/_private/marshaller.py`   | Outgoing wire encoder (Cythonized)                               |
+| `src/dbus_fast/_private/unmarshaller.py` | Incoming wire decoder (Cythonized; endian-sensitive)             |
+| `src/dbus_fast/_private/address.py`      | Bus address parser (Cythonized)                                  |
+| `src/dbus_fast/auth.py`                  | EXTERNAL / ANONYMOUS SASL handshake                              |
+| `src/dbus_fast/errors.py`                | Exception hierarchy rooted at `DBusFastError`                    |
+| `src/dbus_fast/constants.py`             | `BusType`, `MessageType`, `MessageFlag`, etc.                    |
+| `src/dbus_fast/validators.py`            | Bus / interface / member / object-path validators                |
+| `src/dbus_fast/introspection.py`         | XML introspection parser/emitter                                 |
+| `tests/`                                 | Pytest suite — run under `dbus-run-session`                      |
+| `tests/benchmarks/`, `bench/`            | CodSpeed benchmarks                                              |
+| `build_ext.py`                           | Cython build step + `TO_CYTHONIZE` list                          |
+
+## Things not to do
+
+- **Don't introduce 3.11+-only syntax** — the package supports
+  3.10+ and pyupgrade is pinned to `--py310-plus`.
+- **Don't change a Cythonized module's public signature
+  without updating its `.pxd`** — the extension will silently
+  pick up a stale declaration or fall back to pure Python.
+- **Don't commit Cython build outputs** (`*.c`, `*.html`, `*.so`)
+  into the source tree as part of an unrelated change. They're
+  regenerated by `build_ext.py`.
+- **Don't pick a Conventional Commit type that under- or over-
+  states the release impact.** `chore:` for a user-visible
+  bugfix hides it from the changelog; `feat!:` for an internal
+  refactor mints a fake major release.
+- **Don't add `Co-Authored-By` trailers for LLM tools.** Project
+  preference — see _Commit / PR conventions_ above.
+- **Don't bypass `BuildExt`'s exception swallowing in
+  `build_ext.py` without thought.** The pure-Python fallback is
+  a feature for source installs on platforms without a compiler.


### PR DESCRIPTION
## Summary

Adds a structured orientation file (`CLAUDE.md`) for LLM contributors, modeled after [esphome/aioesphomeapi#1646](https://github.com/esphome/aioesphomeapi/pull/1646), and a `pr-workflow` skill under `.claude/skills/pr-workflow/SKILL.md` walking through filling out PRs for this repo.

`CLAUDE.md` covers:

- **What this project is** — D-Bus client/server library with `aio` and `glib` backends; Cython on hot paths; powers Home Assistant and bluetooth-devices D-Bus integrations.
- **Code style** — terse single-line docstrings, comment discipline (don't restate the body, don't pad with issue refs), ruff/isort settings (`profile = "black"`, line length 88), py310 floor, pyupgrade `--py310-plus`.
- **Commit / PR conventions** — Conventional Commits enforced by both `commitlint` (per-commit) and `pr-title.yml` (PR title); accepted types and lowercase-subject rule; no `Co-Authored-By` trailers for LLM authorship; `python-semantic-release` reads the commit log so the type matters.
- **Running tests** — under `dbus-run-session`, against the 3.10–3.14 + `3.14t` × `SKIP_CYTHON` / `REQUIRE_CYTHON` matrix, plus the s390x big-endian leg.
- **Build conventions** — `TO_CYTHONIZE` list, `BuildExt`'s exception swallowing for source installs, `.pxd` discipline (update in the same commit), free-threading-compatible build, `cython.compiled` guards.
- **Useful entry points** table covering both backends, the wire-level core, marshaller/unmarshaller, validators, etc.
- **Things not to do** — 3.11+-only syntax, mismatched `.pxd`, committed build outputs, mis-typed Conventional Commits, `Co-Authored-By` for LLMs.

The `pr-workflow` skill summarises the parts that matter at PR-creation time:

- Branch from `origin/main` (no fork in this workflow).
- Both commit subjects AND the PR title must pass Conventional Commits — two separate CI gates (`commitlint` on commits, `pr-title.yml` on the title, since GitHub uses the PR title as the squash-merge subject).
- Pick a type that matches release impact (`feat:` minor, `fix:`/`perf:` patch, `!` or `BREAKING CHANGE:` major; `chore:`/`docs:`/`test:`/`ci:`/`style:`/`build:`/`refactor:` don't bump) — `python-semantic-release` slots release notes from this.
- No PR template, so the body is freeform.
- Use `--body-file` (not `--body "..."`) so backticks/Markdown survive shell quoting.
- A red `test_big_endian` job almost always means a byte-order assumption leaked into `_private/marshaller.py` or `_private/unmarshaller.py`.

No runtime code changes; this PR only adds contributor-facing documentation under `CLAUDE.md` and `.claude/`.

## Test plan

- [x] Pre-commit hooks pass locally (`ruff`, `prettier`, `trailing-whitespace`, `end-of-file-fixer`).
- [x] Commit subject and PR title both follow Conventional Commits (`docs:` prefix, lowercase subject) — should pass both the `commitlint` and `pr-title` workflows.
