### PR TITLE
ci: install libgirepository-2.0-dev for PyGObject 3.56+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install libs
-        run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+        run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
       - uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
@@ -88,7 +88,7 @@ jobs:
           distro: ubuntu_latest
           run: |
             apt-get -y update
-            apt-get -y install git python3-pip python3-venv python3-poetry dbus-daemon python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+            apt-get -y install git python3-pip python3-venv python3-poetry dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
             git clone --depth 1 $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
             cd dbus-fast
             git fetch origin --depth 1 $GITHUB_SHA
@@ -101,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install libs
-        run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+        run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
       - uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
       - name: Setup Python 3.14
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5


### PR DESCRIPTION
## Summary
- PyGObject 3.56 switched build deps from `girepository-1.0` to `girepository-2.0`, so dependabot bumps past 3.50 (e.g. #631) fail with `Dependency 'girepository-2.0' is required but not found`.
- Install `libgirepository-2.0-dev` alongside the existing `libgirepository1.0-dev` in the `test`, `benchmark`, and `test_big_endian` jobs (Ubuntu 24.04 / `ubuntu_latest` has both packages).
- Unblocks #631 and any future PyGObject bumps.

## Test plan
- [ ] CI passes on this PR (test, benchmark, big-endian s390x) with the new package installed.
- [ ] After merge, rebase #631 and confirm pygobject 3.56.3 builds and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)