### PR TITLE
ci: ignore pygobject 3.56 AbstractEventLoopPolicy DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ pythonpath = ["src"]
 filterwarnings = [
     "error",
     '''ignore:The global interpreter lock \(GIL\) has been enabled to load module 'gi\._gi'.*:RuntimeWarning''',
+    # PyGObject 3.56's gi.events module references asyncio.AbstractEventLoopPolicy
+    # at import time; Python 3.14 deprecated it (removal in 3.16).
+    '''ignore:'asyncio\.AbstractEventLoopPolicy' is deprecated.*:DeprecationWarning''',
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
Follow-up to #648. With pygobject 3.56 now buildable in CI, the `pygobject` bump in #631 surfaced a second issue:

- `gi/events.py` (pygobject ≥3.56) references `asyncio.AbstractEventLoopPolicy` at import time.
- Python 3.14 deprecated that attribute (removal scheduled for 3.16), so the access triggers a `DeprecationWarning`.
- Our pytest `filterwarnings = ["error", ...]` config promotes that warning to a test failure for every `glib_*` test that transitively imports `gi.events` (7 tests on 3.14 / 3.14t).

This adds a narrowly scoped ignore so the warning doesn't fail the suite. We don't use `AbstractEventLoopPolicy` anywhere in `src/` or `tests/`, so the filter only suppresses the third-party warning. Unblocks #631 once dependabot rebases.

## Test plan
- [ ] CI passes here on 3.14 / 3.14t (still on pygobject 3.50, filter is a no-op).
- [ ] After merge, rebase #631 and confirm 3.14 / 3.14t go green with pygobject 3.56.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)