### PR TITLE
ci: widen asyncio policy DeprecationWarning filter for pygobject 3.56

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,10 @@ pythonpath = ["src"]
 filterwarnings = [
     "error",
     '''ignore:The global interpreter lock \(GIL\) has been enabled to load module 'gi\._gi'.*:RuntimeWarning''',
-    # PyGObject 3.56's gi.events module references asyncio.AbstractEventLoopPolicy
-    # at import time; Python 3.14 deprecated it (removal in 3.16).
-    '''ignore:'asyncio\.AbstractEventLoopPolicy' is deprecated.*:DeprecationWarning''',
+    # PyGObject 3.56's gi.events module uses the asyncio event loop policy API
+    # (AbstractEventLoopPolicy, get_event_loop_policy, ...) which Python 3.14
+    # deprecated in full (removal in 3.16).
+    '''ignore:'asyncio\.[A-Za-z_]*[Pp]olicy[A-Za-z_]*' is deprecated.*:DeprecationWarning''',
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
Follow-up to #649. That PR only ignored `'asyncio.AbstractEventLoopPolicy' is deprecated`, but pygobject 3.56's `gi/events.py:890` also calls `asyncio.get_event_loop_policy()`, which Python 3.14 deprecated under a separate name. The 7 glib tests still fail on 3.14 / 3.14t in #631.

Widen the regex to match every deprecation message of the form `'asyncio.<…Policy…>' is deprecated …`. Tested locally against all the deprecated names (`AbstractEventLoopPolicy`, `DefaultEventLoopPolicy`, `WindowsSelectorEventLoopPolicy`, `get_event_loop_policy`, `set_event_loop_policy`, `_get_event_loop_policy`) — all match — and confirmed it does **not** match unrelated asyncio deprecations like `asyncio.get_event_loop`.

## Test plan
- [ ] CI passes here (no-op on pygobject 3.50, just a wider regex).
- [ ] Rebase #631 after merge and confirm 3.14 / 3.14t green with pygobject 3.56.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)