### PR TITLE
docs: add SECURITY.md with private vulnerability reporting policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,17 @@ body.
   (`exclude_also = ["if cython.compiled:"]`) — don't count their
   absence in coverage as a missing test.
 
+## Reporting security issues
+
+Suspected security vulnerabilities go through GitHub's [private
+vulnerability reporting][gh-report], not public issues or pull
+requests. The policy is spelled out in [SECURITY.md](SECURITY.md).
+If a user describes what sounds like a vulnerability in chat,
+point them at that route instead of opening a public issue, PR,
+or commit that names the bug class and the affected code path.
+
+[gh-report]: https://github.com/Bluetooth-Devices/dbus-fast/security/advisories/new
+
 ## Useful entry points
 
 | Path                                     | What                                                             |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately through GitHub's
+[private vulnerability reporting][gh-report] for this repository.
+That route sends the report directly to the maintainers and lets
+us coordinate a fix, a CVE, and a release before public
+disclosure.
+
+**Do not** open a regular GitHub issue, a pull request, or post
+to a public channel (mailing list, chat room, Stack Overflow,
+etc.) for a suspected vulnerability. If you are unsure whether
+something is a vulnerability, use the private report — we would
+rather see a false alarm than a public one.
+
+We aim to acknowledge new reports within a few business days.
+
+[gh-report]: https://github.com/Bluetooth-Devices/dbus-fast/security/advisories/new
+
+## Supported versions
+
+Security fixes are released against the latest `4.x` line on
+PyPI. Older releases are not maintained — please upgrade to the
+current release before reporting, and confirm the issue still
+reproduces there.
+
+## Scope
+
+`dbus-fast` is a D-Bus client/server library. By design it
+exchanges wire-format frames with a `dbus-daemon` over a Unix
+socket, so any process the daemon has admitted to the bus can
+deliver bytes to the parsing code. In-scope issues include:
+
+- Memory-safety, parsing, or denial-of-service issues triggered
+  by crafted D-Bus messages or type signatures reaching the
+  unmarshaller (`_private/unmarshaller.py`), the marshaller
+  (`_private/marshaller.py`), the signature parser
+  (`signature.py`), or the address parser (`_private/address.py`).
+- Authentication-handshake flaws in `auth.py` (SASL EXTERNAL /
+  ANONYMOUS / DBUS_COOKIE_SHA1) that let a peer connect, escalate,
+  or impersonate beyond what the bus policy permits.
+- Logic bugs in `message_bus.py` / `aio/message_bus.py` /
+  `service.py` that cause the library to dispatch, expose, or
+  reply to a method or signal it should not — including bypasses
+  of the matching/registration rules a caller relied on.
+- Issues in the build / packaging pipeline (`build_ext.py`,
+  Cython output in `TO_CYTHONIZE`, wheel contents, signed-release
+  flow) that could lead to a compromised wheel on PyPI.
+
+Out of scope:
+
+- Risks inherent to running on a shared D-Bus instance — D-Bus
+  access control is enforced by `dbus-daemon`'s own policy files,
+  not by this library. Reports of the form "a co-resident
+  process the daemon admitted can call my exported method" are
+  expected behaviour unless they cross one of the lines above.
+- Running `dbus-daemon` over an unauthenticated TCP transport,
+  or other deployment-side misconfiguration of the bus.
+- Misuse of the API by a consuming application (e.g. exporting a
+  privileged method without any caller check) — that is the
+  consumer's policy decision, not a library bug.


### PR DESCRIPTION
## Summary

Add a `SECURITY.md` that directs vulnerability reports through GitHub's [private vulnerability reporting](https://github.com/Bluetooth-Devices/dbus-fast/security/advisories/new), so reporters have a documented private channel and aren't tempted to open a public issue or PR. Cross-reference the policy from `CLAUDE.md` so future LLM-assisted contributions route reports the same way. Modeled on [python-zeroconf#1675](https://github.com/python-zeroconf/python-zeroconf/pull/1675).

## Details

- **`SECURITY.md`** — top-level file (where GitHub's Security tab looks for it). Names the supported channel, supported versions (latest `4.x`), and an in-scope / out-of-scope list grounded in `dbus-fast`'s actual attack surface:
  - Crafted D-Bus messages / type signatures hitting `_private/unmarshaller.py`, `_private/marshaller.py`, `signature.py`, `_private/address.py`.
  - SASL handshake flaws in `auth.py` (EXTERNAL / ANONYMOUS / DBUS_COOKIE_SHA1).
  - Dispatch / matching bugs in `message_bus.py`, `aio/message_bus.py`, `service.py` that expose or reply to something they shouldn't.
  - Build / packaging pipeline (`build_ext.py`, `TO_CYTHONIZE`, wheel contents, signed-release flow).
  - **Out of scope:** anything that's enforced by `dbus-daemon`'s own policy (D-Bus access control is the daemon's job), running `dbus-daemon` over an unauthenticated TCP transport, or consumer-side misuse of the API.
- **`CLAUDE.md`** — new `## Reporting security issues` section between `## Build conventions` and `## Useful entry points`. Tells the LLM contributor not to open a public issue, PR, or commit naming the bug class and the affected code path when a user describes a suspected vulnerability; instead, point them at `SECURITY.md` / the private-reporting URL.

## Test plan

- [ ] `SECURITY.md` is discoverable via GitHub's Security tab after merge (`/security/policy` resolves).
- [ ] The "Report a vulnerability" button on the Security tab leads to `/security/advisories/new`.
- [ ] `lint` and `commitlint` jobs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)