### PR TITLE
ci: use uv to install poetry in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install libs
         run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
-      - uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:
@@ -102,7 +107,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install libs
         run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
-      - uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Setup Python 3.14
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
         with:


### PR DESCRIPTION
## Summary

Mirror of [python-zeroconf/python-zeroconf#1673](https://github.com/python-zeroconf/python-zeroconf/pull/1673) (which mirrors [esphome/aioesphomeapi#1650](https://github.com/esphome/aioesphomeapi/pull/1650)) for `dbus-fast`. Speeds up CI by replacing the slow `snok/install-poetry` provisioning with `astral-sh/setup-uv` + `uv tool install poetry`. No production code is touched.

## Details

- **`test` job** — adds `astral-sh/setup-uv@v8.1.0` (SHA-pinned, `enable-cache: true`) before installing poetry, then runs `uv tool install poetry` in place of `snok/install-poetry@v1.4.1`. `setup-python`'s `cache: "poetry"` is preserved — it caches the per-job project venv keyed off `poetry.lock`, which is independent of how poetry itself reaches `PATH`.
- **`benchmark` job** — same swap.
- **`test_big_endian` job** — left alone. It runs inside an s390x container via `uraimo/run-on-arch-action` and installs poetry from apt (`python3-poetry`); uv isn't on that path.

Win is per-job, so it compounds across the test matrix (CPython 3.10–3.14, 3.14t × `skip_cython`/`use_cython` on ubuntu-latest = 12 jobs). Steady-state behaviour is unchanged; the speed-up shows up on every job's poetry-install step.

## Test plan

- [ ] CI `test` matrix is green across all 12 rows (the workflow change is exercised by every job on this PR).
- [ ] CI `benchmark` job runs to completion and CodSpeed posts a delta.
- [ ] `test_big_endian` still passes (unchanged).
- [ ] `lint` and `commitlint` jobs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)