### PR TITLE
fix(unmarshaller): cap message size at 128 MiB per d-bus spec

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -23,6 +23,7 @@ cdef unsigned int HEADER_SIGNATURE_SIZE
 cdef unsigned int LITTLE_ENDIAN
 cdef unsigned int BIG_ENDIAN
 cdef unsigned int PROTOCOL_VERSION
+cdef unsigned int _MAX_MESSAGE_SIZE
 
 
 cdef unsigned int HEADER_PATH_IDX

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -67,6 +67,15 @@ UINT16_UNPACK_BIG_ENDIAN = Struct(f">{UINT16_CAST}").unpack_from
 HEADER_SIGNATURE_SIZE = 16
 HEADER_ARRAY_OF_STRUCT_SIGNATURE_POSITION = 12
 
+# D-Bus spec: total message length must not exceed 128 MiB. Enforced on the
+# attacker-controlled header_len / body_len fields before any allocation or
+# socket read sized by them, so a forged header can't push the process into
+# an OOM. https://dbus.freedesktop.org/doc/dbus-specification.html
+# MAX_MESSAGE_SIZE is the Python-importable form (used by tests);
+# _MAX_MESSAGE_SIZE is the cdef unsigned int form used internally per .pxd.
+MAX_MESSAGE_SIZE = 134_217_728
+_MAX_MESSAGE_SIZE = MAX_MESSAGE_SIZE
+
 
 # Most common signatures
 
@@ -788,6 +797,16 @@ class Unmarshaller:
             self._uint32_unpack = UINT32_UNPACK_BIG_ENDIAN
             self._int16_unpack = INT16_UNPACK_BIG_ENDIAN
             self._uint16_unpack = UINT16_UNPACK_BIG_ENDIAN
+
+        if (
+            self._body_len > _MAX_MESSAGE_SIZE
+            or self._header_len > _MAX_MESSAGE_SIZE
+            or self._body_len + self._header_len > _MAX_MESSAGE_SIZE
+        ):
+            raise InvalidMessageError(
+                f"message size exceeds maximum {_MAX_MESSAGE_SIZE}: "
+                f"header={self._header_len}, body={self._body_len}"
+            )
 
         # align 8
         self._msg_len = self._header_len + (-self._header_len & 7) + self._body_len

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -71,6 +71,16 @@ HEADER_ARRAY_OF_STRUCT_SIGNATURE_POSITION = 12
 # attacker-controlled header_len / body_len fields before any allocation or
 # socket read sized by them, so a forged header can't push the process into
 # an OOM. https://dbus.freedesktop.org/doc/dbus-specification.html
+#
+# The check in _read_header bounds header_len and body_len independently
+# (each <= 128 MiB, sum <= 128 MiB). The actual on-wire read in _read_body
+# is HEADER_SIGNATURE_SIZE + _msg_len, where _msg_len adds up to 7 bytes of
+# header-to-body alignment padding — so the worst-case read is the cap plus
+# HEADER_SIGNATURE_SIZE (16) + 7 = 23 bytes of slack. That's deliberate: the
+# DoS vector is "buffer gigabytes from a forged header", and 23 bytes over
+# the spec ceiling doesn't change that. Keeping the check on the raw fields
+# is simpler than computing the padded total here.
+#
 # MAX_MESSAGE_SIZE is the Python-importable form (used by tests);
 # _MAX_MESSAGE_SIZE is the cdef unsigned int form used internally per .pxd.
 MAX_MESSAGE_SIZE = 134_217_728

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -11,12 +11,14 @@ from dbus_fast import Message, MessageFlag, MessageType, SignatureTree, Variant
 from dbus_fast._private._cython_compat import FakeCython
 from dbus_fast._private.constants import BIG_ENDIAN, LITTLE_ENDIAN
 from dbus_fast._private.unmarshaller import (
+    MAX_MESSAGE_SIZE,
     Unmarshaller,
     buffer_to_int16,
     buffer_to_uint16,
     buffer_to_uint32,
     is_compiled,
 )
+from dbus_fast.errors import InvalidMessageError
 from dbus_fast.signature import SignatureType
 from dbus_fast.unpack import unpack_variants
 
@@ -974,3 +976,42 @@ def test_read_variant_truncated_byte_value() -> None:
     trunc = _truncate_body(full, 3)
     with pytest.raises(IndexError):
         Unmarshaller(io.BytesIO(bytes(trunc))).unmarshall()
+
+
+def _forged_header(body_len: int, header_len: int, endian: str = "<") -> bytes:
+    """Build a 16-byte header with attacker-chosen body_len and header_len."""
+    endian_byte = b"l" if endian == "<" else b"B"
+    header = bytearray(endian_byte + bytes([1, 0, 1]))
+    header += struct.pack(f"{endian}I", body_len)
+    header += struct.pack(f"{endian}I", 1)
+    header += struct.pack(f"{endian}I", header_len)
+    return bytes(header)
+
+
+def test_unmarshall_rejects_oversized_body_len() -> None:
+    """body_len above the 128 MiB cap raises before any body read."""
+    forged = _forged_header(body_len=MAX_MESSAGE_SIZE + 1, header_len=0)
+    with pytest.raises(InvalidMessageError, match="exceeds maximum"):
+        Unmarshaller(io.BytesIO(forged)).unmarshall()
+
+
+def test_unmarshall_rejects_oversized_header_len() -> None:
+    """header_len above the 128 MiB cap raises before any body read."""
+    forged = _forged_header(body_len=0, header_len=MAX_MESSAGE_SIZE + 1)
+    with pytest.raises(InvalidMessageError, match="exceeds maximum"):
+        Unmarshaller(io.BytesIO(forged)).unmarshall()
+
+
+def test_unmarshall_rejects_oversized_combined_size() -> None:
+    """body_len + header_len above the cap raises even when each is in range."""
+    half = MAX_MESSAGE_SIZE // 2 + 1
+    forged = _forged_header(body_len=half, header_len=half)
+    with pytest.raises(InvalidMessageError, match="exceeds maximum"):
+        Unmarshaller(io.BytesIO(forged)).unmarshall()
+
+
+def test_unmarshall_rejects_max_uint32_body_len_big_endian() -> None:
+    """A forged big-endian header with body_len=0xFFFFFFFF raises."""
+    forged = _forged_header(body_len=0xFFFFFFFF, header_len=0, endian=">")
+    with pytest.raises(InvalidMessageError, match="exceeds maximum"):
+        Unmarshaller(io.BytesIO(forged)).unmarshall()


### PR DESCRIPTION
## What

Enforce the D-Bus spec 128 MiB total-message-size cap in the unmarshaller. `_read_header` now validates `body_len` and `header_len` (and their sum) immediately after reading them, before `_msg_len` is computed and before `_read_to_pos` can size an allocation or `recvmsg` from those untrusted values.

## Why

`_read_header` previously consumed both length fields as raw `uint32`s from the wire, then handed `HEADER_SIGNATURE_SIZE + _msg_len` to `_read_to_pos`. A single 28-byte forged header claiming `body_len = 0xFFFFFFFF` forced the victim to attempt to buffer ~4 GiB before any validation — a remote DoS against any peer that subscribes to messages on a shared system bus.

Captured as #641; the TODO at `message.py:324` noted the missing cap but only on the outbound (marshal) side.

## How

- Added `MAX_MESSAGE_SIZE = 134_217_728` (Python-importable) and `_MAX_MESSAGE_SIZE` (cdef'd `unsigned int`) so the bounds check compiles to a native C compare on the hot path.
- In `_read_header`, raise `InvalidMessageError` if either field — or their sum — exceeds the cap. The check runs before `_msg_len` is computed, so no allocation or socket read is ever attempted at the attacker-chosen size.

## Tests

Four new tests in `tests/test_marshaller.py` build forged 16-byte headers (no body bytes follow) and assert `InvalidMessageError` is raised — the absence of a body proves validation runs before any body read:

- `test_unmarshall_rejects_oversized_body_len`
- `test_unmarshall_rejects_oversized_header_len`
- `test_unmarshall_rejects_oversized_combined_size`
- `test_unmarshall_rejects_max_uint32_body_len_big_endian` — the original `body_len=0xFFFFFFFF` payload from the issue

closes #641
