### PR TITLE
fix(signature): cap get_signature_tree lru_cache to 4096 entries

### DIFF
--- a/src/dbus_fast/signature.py
+++ b/src/dbus_fast/signature.py
@@ -473,7 +473,12 @@ class Variant:  # noqa: PLW1641
         return f"<dbus_fast.signature.Variant ('{self.type.signature}', {self.value})>"
 
 
-get_signature_tree = lru_cache(maxsize=None)(SignatureTree)
+# Bound the cache so a peer streaming messages with unique attacker-chosen
+# signatures (signatures up to 255 bytes, body-side signatures pass through
+# get_signature_tree in the unmarshaller) cannot grow this dict without
+# limit and OOM the process. 4096 entries covers every signature emitted
+# by real-world D-Bus services many times over.
+get_signature_tree = lru_cache(maxsize=4096)(SignatureTree)
 """Get a signature tree for the given signature.
 
 :param signature: The signature to get a tree for.

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -4,7 +4,7 @@ from dbus_fast import SignatureBodyMismatchError, SignatureTree, Variant
 from dbus_fast._private.unmarshaller import is_compiled
 from dbus_fast._private.util import signature_contains_type
 from dbus_fast.errors import InternalError, InvalidSignatureError
-from dbus_fast.signature import SignatureType
+from dbus_fast.signature import SignatureType, get_signature_tree
 
 
 def assert_simple_type(signature, type_):
@@ -580,3 +580,28 @@ def test_verify_raises_internal_error_when_validator_missing(monkeypatch):
     monkeypatch.delitem(SignatureType.validators, "i")
     with pytest.raises(InternalError):
         sig_type.verify(123)
+
+
+def test_get_signature_tree_cache_is_bounded() -> None:
+    """The lru_cache on get_signature_tree must declare a finite maxsize."""
+    info = get_signature_tree.cache_info()
+    assert info.maxsize is not None
+    assert info.maxsize <= 8192
+
+
+def test_get_signature_tree_cache_evicts_under_unique_stream() -> None:
+    """Streaming more unique signatures than maxsize must not grow the cache."""
+    info = get_signature_tree.cache_info()
+    maxsize = info.maxsize
+    assert maxsize is not None
+
+    # Encode the index in 14 bits across two DBus type chars (y, i) so each
+    # signature is unique, short, and well under the 255-char signature
+    # length cap.
+    overflow = maxsize * 2
+    width = overflow.bit_length()
+    for n in range(overflow):
+        sig = f"{n:b}".zfill(width).translate(str.maketrans("01", "yi"))
+        get_signature_tree(sig)
+
+    assert get_signature_tree.cache_info().currsize <= maxsize


### PR DESCRIPTION
## What

Replace `get_signature_tree = lru_cache(maxsize=None)(SignatureTree)` with `maxsize=4096`. The cap is high enough that no real-world D-Bus service can come close (typical introspections emit dozens of unique signatures per service) but puts a hard ceiling on worst-case memory.

## Why

The unmarshaller calls `get_signature_tree(signature)` on attacker-controlled signatures from the wire:

- `_read_variant` fallback path (`src/dbus_fast/_private/unmarshaller.py:599`)
- `_read_body` for arbitrary body signatures (`src/dbus_fast/_private/unmarshaller.py:818, 843`)

Signatures can be up to 255 bytes, and entries are never evicted from `maxsize=None`. A peer able to send messages or signals the victim subscribes to (any unprivileged peer on a shared bus) could stream messages with continually-unique signatures and grow the cache without bound until the process is OOM-killed. Slow but deterministic, and the "no eviction" property means the attack persists even after the malicious peer disconnects.

## Tests

`tests/test_signature.py`:

- `test_get_signature_tree_cache_is_bounded` — pin that `cache_info().maxsize` is finite and ≤ 8192 (so future "performance" PRs can't quietly remove the cap).
- `test_get_signature_tree_cache_evicts_under_unique_stream` — feed `maxsize * 2` unique valid signatures (binary-encoded indices mapped to `y` / `i`) and assert `currsize <= maxsize` afterwards — pins the bound holds regardless of which cache implementation is wired up.

closes #644
