### PR TITLE
fix: stop sending python tracebacks to remote dbus callers

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -6,7 +6,6 @@ import inspect
 import io
 import logging
 import socket
-import traceback
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from contextlib import ExitStack
@@ -828,13 +827,17 @@ class BaseMessageBus:
                     break
                 _LOGGER.exception("A message handler raised an exception: %s", e)
             except Exception as e:
+                # Log the full traceback for the operator, but never send it
+                # back to the caller — it discloses install paths, line
+                # numbers, locals and version fingerprints to any peer that
+                # can invoke a method on this bus.
                 _LOGGER.exception("A message handler raised an exception: %s", e)
                 if msg.message_type is MESSAGE_TYPE_CALL:
                     self.send(
                         Message.new_error(
                             msg,
                             ErrorType.INTERNAL_ERROR,
-                            f"An internal error occurred: {e}.\n{traceback.format_exc()}",
+                            f"An internal error occurred: {type(e).__name__}",
                         )
                     )
                     handled = True

--- a/src/dbus_fast/send_reply.py
+++ b/src/dbus_fast/send_reply.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import traceback
+import logging
 from types import TracebackType
 from typing import TYPE_CHECKING
 
@@ -10,6 +10,8 @@ from .message import Message
 
 if TYPE_CHECKING:
     from .message_bus import BaseMessageBus
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class SendReply:
@@ -38,11 +40,19 @@ class SendReply:
             if isinstance(exc_value, DBusError):
                 self(exc_value._as_message(self._msg))
             else:
+                # Log the traceback for the operator; never send it back to
+                # the caller — it discloses install paths, line numbers,
+                # locals and version fingerprints to any peer that can
+                # invoke a method on this service.
+                _LOGGER.exception(
+                    "Service interface raised an exception",
+                    exc_info=(exc_type, exc_value, tb),
+                )
                 self(
                     Message.new_error(
                         self._msg,
                         ErrorType.SERVICE_ERROR,
-                        f"The service interface raised an error: {exc_value}.\n{traceback.format_tb(tb)}",
+                        f"The service interface raised an error: {type(exc_value).__name__}",
                     )
                 )
             return True

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -230,6 +230,13 @@ async def test_methods(interface_class):
     reply = await call("throws_unexpected_error")
     assert reply.message_type == MessageType.ERROR, reply.body[0]
     assert reply.error_name == ErrorType.SERVICE_ERROR.value, reply.body[0]
+    # The body must not leak a traceback (paths, line numbers, locals) or
+    # the exception's str(); only the exception class name is disclosed.
+    body = reply.body[0]
+    assert "Traceback" not in body, body
+    assert 'File "' not in body, body
+    assert "oops" not in body, body
+    assert "Exception" in body, body
 
     reply = await call("throws_dbus_error")
     assert reply.message_type == MessageType.ERROR, reply.body[0]

--- a/tests/test_aio_low_level.py
+++ b/tests/test_aio_low_level.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from dbus_fast import Message, MessageFlag, MessageType
+from dbus_fast import ErrorType, Message, MessageFlag, MessageType
 from dbus_fast.aio import MessageBus
 
 
@@ -180,6 +180,45 @@ async def test_sending_signals_between_buses():
     assert signal.member == "SomeSignal"
     assert signal.signature == "s"
     assert signal.body == ["a signal"]
+
+    bus1.disconnect()
+    bus2.disconnect()
+    await asyncio.wait_for(bus1.wait_for_disconnect(), timeout=1)
+    await asyncio.wait_for(bus2.wait_for_disconnect(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_internal_error_reply_does_not_leak_traceback() -> None:
+    """A raising message handler must surface as a sanitized INTERNAL_ERROR."""
+    bus1 = await MessageBus().connect()
+    bus2 = await MessageBus().connect()
+
+    msg = Message(
+        destination=bus1.unique_name,
+        path="/org/test/path",
+        interface="org.test.iface",
+        member="SomeMember",
+        serial=bus2.next_serial(),
+    )
+
+    def raising_handler(sent):
+        if sent.sender == bus2.unique_name and sent.serial == msg.serial:
+            bus1.remove_message_handler(raising_handler)
+            raise ValueError("must not appear on the wire")
+
+    bus1.add_message_handler(raising_handler)
+
+    reply = await bus2.call(msg)
+
+    assert reply.message_type == MessageType.ERROR
+    assert reply.error_name == ErrorType.INTERNAL_ERROR.value
+    body = reply.body[0]
+    # The body must not leak a Python traceback, file paths, or the
+    # exception's str() — only the exception class name is disclosed.
+    assert "Traceback" not in body, body
+    assert 'File "' not in body, body
+    assert "must not appear on the wire" not in body, body
+    assert "ValueError" in body, body
 
     bus1.disconnect()
     bus2.disconnect()

--- a/tests/test_send_reply.py
+++ b/tests/test_send_reply.py
@@ -85,7 +85,14 @@ def test_send_reply_generic_exception(
     assert messages[0].message_type == MessageType.ERROR
     assert messages[0].error_name == ErrorType.SERVICE_ERROR.value
     assert messages[0].reply_serial == 1
-    assert "boom" in messages[0].body[0]
+    # The wire body must disclose only the exception class name — never the
+    # str() of the exception (might contain caller data) and never a Python
+    # traceback (paths, line numbers, locals).
+    body = messages[0].body[0]
+    assert "boom" not in body, body
+    assert "Traceback" not in body, body
+    assert 'File "' not in body, body
+    assert "RuntimeError" in body, body
 
 
 def test_send_reply_send_error(


### PR DESCRIPTION
## What

Sanitize the two error-response bodies that were embedding `traceback.format_exc()` / `traceback.format_tb()` verbatim in messages sent back to remote callers. The wire body now contains only the exception class name; the full traceback is logged locally via `_LOGGER.exception` for operator diagnostics.

## Why

A method handler that raised an unexpected exception sent back a body like:

```
An internal error occurred: ValueError('bad signature').
Traceback (most recent call last):
  File "/home/nick/.local/lib/python3.13/site-packages/dbus_fast/message_bus.py", line 818, in _process_message
    ...
```

That discloses absolute filesystem paths (revealing the install location and user-account names like `/home/<user>/.../site-packages/...`), exact source line numbers, function names, locals referenced in frames, and library versions to any peer that can invoke a method on the service. On the system bus this means any unprivileged process. The information is useful for an attacker chaining further exploits (path-traversal targeting, version fingerprinting, internal class structure for crafted payloads) and unnecessary for legitimate callers, who only need to know the call failed.

Two sites were leaking:

1. `src/dbus_fast/message_bus.py:837` — `INTERNAL_ERROR` reply for a raising `add_message_handler` callback. This is the path #645 calls out.
2. `src/dbus_fast/send_reply.py:45` — `SERVICE_ERROR` reply for a raising exported service-interface method. **Sibling leak the issue did not flag**; same class of bug, same fix.

## How

Both bodies become `"<prefix>: <ExceptionClass>"`. The full traceback is logged via `_LOGGER.exception` on the bus side so operators retain diagnostics. `send_reply.py` gains its own module logger since it had none.

`import traceback` removed from `message_bus.py` (no longer needed); `send_reply.py` drops `traceback` in favour of `logging`.

## Tests

- `tests/service/test_methods.py::test_methods` — extended the existing `throws_unexpected_error` assertion to pin the sanitized `SERVICE_ERROR` body (no `Traceback`, no `File "`, no `str(e)` content; class name `Exception` present).
- `tests/test_aio_low_level.py::test_internal_error_reply_does_not_leak_traceback` — new test for the `INTERNAL_ERROR` path: registers an `add_message_handler` callback that raises `ValueError("must not appear on the wire")`, sends a call, asserts the reply body is sanitized (no traceback, no path, no exception message; class name `ValueError` present).

closes #645
