### PR TITLE
ci(s390x): drop pycairo/PyGObject builds and use uv for installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,11 @@ jobs:
             # source under QEMU s390x emulation (~5min), and skip pycairo
             # entirely since the tests don't import cairo.
             uv venv --system-site-packages .venv
-            REQUIRE_CYTHON=1 .venv/bin/uv pip install \
+            . .venv/bin/activate
+            REQUIRE_CYTHON=1 uv pip install \
               -e . \
               pytest pytest-asyncio pytest-cov pytest-timeout covdefaults
-            dbus-run-session -- .venv/bin/pytest --no-cov --timeout=100
+            dbus-run-session -- pytest --no-cov --timeout=100
 
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,22 @@ jobs:
           distro: ubuntu_latest
           run: |
             apt-get -y update
-            apt-get -y install git python3-pip python3-venv python3-poetry dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
-            git clone --depth 1 $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+            apt-get -y install --no-install-recommends \
+              ca-certificates git python3-pip python3-venv python3-dev \
+              gcc dbus-daemon python3-gi
+            pip install --break-system-packages uv
+            git clone --depth 1 "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
             cd dbus-fast
-            git fetch origin --depth 1 $GITHUB_SHA
-            git checkout $GITHUB_SHA
-            REQUIRE_CYTHON=1 poetry install --only=main,dev
-            dbus-run-session -- poetry run pytest --no-cov --timeout=100
+            git fetch origin --depth 1 "$GITHUB_SHA"
+            git checkout "$GITHUB_SHA"
+            # Reuse apt's python3-gi rather than rebuilding PyGObject from
+            # source under QEMU s390x emulation (~5min), and skip pycairo
+            # entirely since the tests don't import cairo.
+            uv venv --system-site-packages .venv
+            REQUIRE_CYTHON=1 .venv/bin/uv pip install \
+              -e . \
+              pytest pytest-asyncio pytest-cov pytest-timeout covdefaults
+            dbus-run-session -- .venv/bin/pytest --no-cov --timeout=100
 
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,8 @@ jobs:
             REQUIRE_CYTHON=1 uv pip install \
               -e . \
               pytest pytest-asyncio pytest-cov pytest-timeout covdefaults
-            dbus-run-session -- pytest --no-cov --timeout=100
+            dbus-run-session -- pytest --no-cov --timeout=100 \
+              --ignore=tests/benchmarks
 
   benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The Big-endian s390x job currently takes ~21 minutes and is intermittently flaky with `BadZipFile: File is not a zip file` errors when poetry downloads the pycairo wheel.

Profile of the current job (successful run on `main`):
- ~9 min: apt-get install (pulls in `python-numpy-doc`, `gfortran`, `beaker`, etc. via Recommends)
- ~10 min: `poetry install --only=main,dev` rebuilding **PyGObject** and **pycairo** from source under QEMU s390x emulation
- ~2 min: actual pytest run

The tests only import `gi.repository.GLib` — no cairo, no Gtk. We can skip both expensive rebuilds:

- Use apt's pre-built `python3-gi` via a `--system-site-packages` venv so PyGObject is **not** rebuilt.
- Skip `pycairo` entirely (unused) — also removes the flaky wheel-download failure mode.
- Drop `libcairo2-dev`, `libgirepository{1.0,-2.0}-dev`, `gir1.2-gtk-3.0`, `pkg-config`, and `python3-poetry` from apt.
- Add `--no-install-recommends` to trim doc/build extras.
- Install `pytest` and friends with `uv pip` instead of poetry, matching the existing uv-first pattern in the `test` and `benchmark` jobs.

## Test plan

- [ ] Big-endian s390x tests job completes faster than the prior baseline (~21 min on `main`).
- [ ] All s390x byte-order tests still pass.