### PR TITLE
perf(build): parallelize cython extension compilation

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -37,6 +37,8 @@ EXTENSIONS = [
 
 class BuildExt(build_ext):
     def build_extensions(self):
+        if self.parallel is None:
+            self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()
         except Exception:


### PR DESCRIPTION
Mirrors python-zeroconf/python-zeroconf#1689; default `BuildExt.parallel` to `os.cpu_count()` so the per-module `clang`/`gcc` compiles run concurrently instead of one at a time. Biggest payoff is the QEMU emulated wheel legs (s390x here), where the serial compile is what dominates the job time.

Local check on macOS arm64 with `REQUIRE_CYTHON=1 python setup.py build_ext --inplace`, the six extension compiles now fire in parallel; `SKIP_CYTHON=1` path is unchanged.