### PR TITLE
fix(ci): drop -- separator in release-job git switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Create local branch name
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
-        run: git switch -C -- "$BRANCH"
+        run: git switch -C "$BRANCH"
 
       # Do a dry run of PSR
       - name: Test release


### PR DESCRIPTION
The release job's `Create local branch name` step fails on PRs with
`fatal: invalid reference: <branch>` (seen on #620).

`-C` is `OPT_STRING` in git's option parser, so it consumes the next
token as its value. In `git switch -C -- "$BRANCH"`, `-C` swallows
`--` and `$BRANCH` becomes the positional switch target. Git then
tries to switch to an existing branch with that name, doesn't find
one in the PR checkout, and exits 128.

Dropping the `--` lets `-C` bind `$BRANCH` as the new-branch name,
which is the original intent.

Failing run: https://github.com/Bluetooth-Devices/dbus-fast/actions/runs/25997057482/job/76413354236

Regression introduced in #624.
