### PR TITLE
chore(ci): pin action comments to full semver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
@@ -38,7 +38,7 @@ jobs:
           - "use_cython"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install libs
         run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
       - name: Set up uv
@@ -48,7 +48,7 @@ jobs:
       - name: Install poetry
         run: uv tool install poetry
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
@@ -63,7 +63,7 @@ jobs:
       - name: Test with Pytest
         run: dbus-run-session -- poetry run pytest --cov-report=xml --timeout=5 --durations=30 --ignore=tests/benchmarks
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: uraimo/run-on-arch-action@1c358dc49363439f8c563ce8f93005f7fe76b849 # v3
         name: Run commands
         id: runcmd
@@ -104,7 +104,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install libs
         run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
       - name: Set up uv
@@ -114,7 +114,7 @@ jobs:
       - name: Install poetry
         run: uv tool install poetry
       - name: Setup Python 3.14
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.14
           cache: "poetry"
@@ -123,7 +123,7 @@ jobs:
           REQUIRE_CYTHON=1 poetry install --only=main,dev
         shell: bash
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c # v3
+        uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c # v4.15.0
         with:
           mode: instrumentation
           token: ${{ secrets.CODSPEED_TOKEN }}
@@ -145,7 +145,7 @@ jobs:
       newest_release_tag: ${{ steps.release_tag.outputs.newest_release_tag }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
@@ -249,7 +249,7 @@ jobs:
           - { os: ubuntu-latest, qemu: riscv64, musl: "", pyver: cp314 }
           - { os: ubuntu-latest, qemu: riscv64, musl: "", pyver: cp314t }
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: "v${{ needs.release.outputs.newest_release_tag }}"
           fetch-depth: 0
@@ -277,7 +277,7 @@ jobs:
           REQUIRE_CYTHON: 1
           CIBW_ARCHS_LINUX: ${{ ( matrix.os == 'ubuntu-24.04-arm' && 'aarch64' ) || matrix.qemu || 'auto' }}
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: ./wheelhouse/*.whl
           name: wheels-${{ matrix.os }}-${{ matrix.musl }}-${{ matrix.qemu }}-${{ matrix.pyver }}
@@ -290,7 +290,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,9 +11,9 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.8
       - name: Install labels


### PR DESCRIPTION
Rewrite the trailing version comments on SHA-pinned GitHub Actions to full semver matching the SHA they actually point at, instead of dropping them (as #623 proposed).

The major-only comments on the `actions/*` pins drifted across multiple major versions without being updated:

| Pin                         | Old comment | Actual version |
| --------------------------- | ----------- | -------------- |
| `actions/checkout`          | `# v4`      | `v6.0.2`       |
| `actions/setup-python`      | `# v5`      | `v6.2.0`       |
| `actions/upload-artifact`   | `# v4`      | `v7.0.1`       |
| `actions/download-artifact` | `# v4`      | `v8.0.1`       |
| `codecov/codecov-action`    | `# v5`      | `v6.0.0`       |
| `CodSpeedHQ/action`         | `# v3`      | `v4.15.0`      |

Dependabot keeps full-semver comments in sync on every bump (see #621, which rewrote `# v3.4.0` → `# v3.4.1` and `# v1.13.0` → `# v1.14.0`), but leaves major-only comments alone — so `# v4` survived a v4 → v5 → v6 → v7 SHA migration on `upload-artifact`. Normalizing to full semver restores reviewer-visible version info now and lets dependabot maintain it going forward.

`uraimo/run-on-arch-action @ 1c358dc…` is left as `# v3` for this PR because the pinned commit is not itself tagged (it's the `master`-side commit that moved the `v3` ref to `v3.0.0`), so there is no clean semver target to rewrite to. `pypa/gh-action-pypi-publish # release/v1` and `python-semantic-release/upload-to-gh-release # main` are branch-tracking refs and are intentionally left alone.

Closes #623.
