### PR TITLE
ci: cache apt packages for test and benchmark jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install libs
-        run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+          version: 1
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -106,7 +109,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - name: Install libs
-        run: sudo apt-get update && sudo apt-get install -y dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: dbus-daemon python3-gi libgirepository1.0-dev libgirepository-2.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+          version: 1
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:


### PR DESCRIPTION
## What

Replaces the inline `sudo apt-get update && sudo apt-get install -y …` step in the `test` matrix and the `benchmark` job with `awalsh128/cache-apt-pkgs-action`, pinned to v1.6.0 by commit SHA.

## Why

`apt-get update && apt-get install` is currently the single biggest time sink in each `test` matrix cell. On the last green run (#25999269859) it took ~50s on a job whose actual pytest run was ~5s — and that ~50s runs 12× in the test matrix plus once in `benchmark`. None of it is cached today.

`cache-apt-pkgs-action` caches the resolved `.deb` files keyed on the package list + the `version: 1` bust knob, restores them on subsequent runs, and skips the `apt-get update`. The package list is unchanged, so behavior on cold-cache runs is the same as before.

## Notes

- `version: 1` lets us invalidate the cache deliberately (e.g. when a new package is added) by bumping the integer.
- s390x and `.venv` caching are intentionally out of scope here and will land as separate PRs.
