### PR TITLE
ci: cache apt and uv downloads for the s390x big-endian job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,31 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Cache s390x apt + uv downloads
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/cache-s390x/apt
+            ~/cache-s390x/uv
+          key: s390x-deps-v1-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          restore-keys: |
+            s390x-deps-v1-
+      - name: Prepare s390x cache mountpoints
+        run: mkdir -p ~/cache-s390x/apt ~/cache-s390x/uv
       - uses: uraimo/run-on-arch-action@1c358dc49363439f8c563ce8f93005f7fe76b849 # v3
         name: Run commands
         id: runcmd
         with:
           arch: s390x
           distro: ubuntu_latest
+          dockerRunArgs: |
+            --volume /home/runner/cache-s390x/apt:/var/cache/apt/archives
+            --volume /home/runner/cache-s390x/uv:/root/.cache/uv
           run: |
+            # Keep downloaded .deb files so the host-side cache picks them up.
+            rm -f /etc/apt/apt.conf.d/docker-clean
+            echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' \
+              > /etc/apt/apt.conf.d/99keep-downloaded
             apt-get -y update
             apt-get -y install --no-install-recommends \
               ca-certificates git python3-pip python3-venv python3-dev \
@@ -115,6 +133,9 @@ jobs:
               pytest pytest-asyncio pytest-cov pytest-timeout covdefaults
             dbus-run-session -- pytest --no-cov --timeout=100 --durations=30 \
               --ignore=tests/benchmarks
+      - name: Reclaim cache dirs for actions/cache save
+        if: always()
+        run: sudo chown -h -R "$(id -u):$(id -g)" ~/cache-s390x || true
 
   benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds the first caching layer to the `test_big_endian` (s390x) job, which previously had **zero** caching:

1. `actions/cache` for `~/cache-s390x/apt` (apt `.deb` archives) and `~/cache-s390x/uv` (uv download cache), keyed on `pyproject.toml` + `poetry.lock` with a `s390x-deps-v1-` prefix so the bust knob is explicit.
2. `dockerRunArgs` bind-mounts those host paths into the QEMU container at `/var/cache/apt/archives` and `/root/.cache/uv` respectively.
3. Inside the container, drops the default `docker-clean` apt config and writes `Binary::apt::APT::Keep-Downloaded-Packages "true";` so the `.deb` files survive `apt-get install`.
4. After the action exits, a `sudo chown -R` on `~/cache-s390x` reclaims the mount contents from root (the container writes as root via the bind mount) so `actions/cache` can save them.

## Why

The s390x leg is the slowest job in CI by a large margin — about 9 minutes on the latest green run (#25999269859) vs ~90s for any other test cell — because everything inside the QEMU emulator was uncached: `apt-get update && install`, `pip install uv`, every dependency wheel.

Caching the apt deb archives + the uv wheel cache cuts the QEMU-side reinstall cost on every push where `poetry.lock` / `pyproject.toml` haven't changed. The Cython compile under emulation still happens (that's the larger remaining cost) but those minutes only need to be amortized across the wheel-download cost going forward; caching the `.so` files inside the inner `git clone` is fragile under the action's bind-mount layout, so it's left for a follow-up.

## Notes

- The `s390x-deps-v1-` prefix in the key lets us bust the cache deliberately (e.g. if apt archive layout changes) by bumping the integer.
- apt deb caching for the host-side `test` and `benchmark` jobs is in #674; venv caching is in #675.
- The `restore-keys` fallback (`s390x-deps-v1-`) means a lockfile bump still warms from the previous cache and only fetches new wheels/debs rather than the full set.
