### PR TITLE
build: pin cython to 3.2.4 for reproducible builds

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1272,7 +1272,7 @@ version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "docs"]
+groups = ["docs"]
 files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
@@ -1287,4 +1287,4 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "6faaa967df5f6430baf671bf12d97f5bb53ac38354284b834857a0cf9d1de49c"
+content-hash = "94130c534f8a6fcfa40104b65eb7a151020a6fac17a2a21755a5bf2c4a8fa367"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ pytest-cov = ">=3,<8"
 pytest-asyncio = ">=0.19,<1.4"
 pycairo = "^1.21.0"
 PyGObject = {version = ">=3.50,<3.57", python = "<4"}
-Cython = ">=3,<3.3.0"
+Cython = "3.2.4"
 setuptools = ">=65.4.1,<83.0.0"
 pytest-timeout = "^2.1.0"
 pytest-codspeed = ">=3.1.1,<5.0.0"
@@ -116,7 +116,7 @@ module = "docs.*"
 ignore_errors = true
 
 [build-system]
-requires = ['setuptools>=65.4.1', 'wheel', 'Cython>=3,<3.3.0', "poetry-core>=1.0.0"]
+requires = ['setuptools>=65.4.1', 'wheel', 'Cython==3.2.4', "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]


### PR DESCRIPTION
## What

Pins Cython to an exact version (`3.2.4`, the version that was already resolving in `poetry.lock`) in two places:

- `[tool.poetry.group.dev.dependencies]` — was `>=3,<3.3.0`
- `[build-system].requires` — was `>=3,<3.3.0`

## Why

Both spots previously declared a range. `[build-system].requires` is the more important one: it's resolved fresh by `pip` build-isolation on every install, *not* from `poetry.lock`, so two builds on the same source tree could pick different Cython versions whenever a new patch landed within the range. Different Cython versions emit subtly different `.c` (and therefore `.so`), which:

- defeats reproducible wheel builds, and
- breaks any cache keyed on source hashes (see #675), because the cached `.so` could disagree with what a fresh build would produce even though no source file changed.

Pinning makes the build deterministic — the same source tree always produces the same `.c`/`.so`. Bumping Cython is now an explicit PR that runs CI + CodSpeed, instead of an invisible drift.

## Notes

- `poetry.lock` already resolved Cython to `3.2.4`, so this just removes the freedom poetry/pip had to drift inside the range. No runtime resolution change.
- The unrelated `urllib3` group-list adjustment in `poetry.lock` is a side-effect of re-running `poetry lock` with poetry 2.2.1 — it corrects a stale group assignment that was already in the lock; it doesn't change which packages are actually installed in either group.
- Future bumps should be normal PRs; dependabot can still propose them.
