### PR TITLE
ci: simplify venv cache key and consolidate poetry env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -37,8 +40,6 @@ jobs:
           - "skip_cython"
           - "use_cython"
     runs-on: ${{ matrix.os }}
-    env:
-      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install libs
@@ -65,7 +66,7 @@ jobs:
           path: |
             .venv
             src/dbus_fast/**/*.so
-          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/dbus_fast/**/*.py', 'src/dbus_fast/**/*.pxd') }}
+          key: venv-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/dbus_fast/**/*.py', 'src/dbus_fast/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
@@ -117,8 +118,6 @@ jobs:
 
   benchmark:
     runs-on: ubuntu-latest
-    env:
-      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install libs
@@ -144,7 +143,7 @@ jobs:
           path: |
             .venv
             src/dbus_fast/**/*.so
-          key: venv-v1-${{ runner.os }}-${{ env.ImageOS }}-${{ env.ImageVersion }}-benchmark-py3.14-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py') }}-${{ hashFiles('src/dbus_fast/**/*.py', 'src/dbus_fast/**/*.pxd') }}
+          key: venv-v1-${{ runner.os }}-benchmark-py3.14-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/dbus_fast/**/*.py', 'src/dbus_fast/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
Follow-up cleanup of the venv cache landed in #675.

## What

Three trims, all behavior-preserving (or, in the first case, eliminating a no-op):

1. **Drop `${{ env.ImageOS }}-${{ env.ImageVersion }}-` from both cache keys.** I'd added these as a "safety" knob meant to invalidate the cache on runner image flips, but they don't actually work as written — `env` context only resolves workflow-declared env vars, not runner process env vars like `ImageOS`/`ImageVersion`. The post-merge run on `main` makes this visible: the emitted key was `venv-v1-Linux---py3.12-use_cython-…` — the `---` is two empty interpolations. They've been doing nothing.
2. **Merge the two `hashFiles()` calls** into a single call covering `poetry.lock`, `pyproject.toml`, `build_ext.py`, `src/dbus_fast/**/*.py`, and `src/dbus_fast/**/*.pxd`. The split into two calls had no functional difference (the resulting cache key is the concatenation either way) and just made the line noisier.
3. **Promote `POETRY_VIRTUALENVS_IN_PROJECT: "true"` to workflow-level `env:`** instead of declaring it on both `test` and `benchmark` jobs. Single source of truth; matches how the rest of the workflow handles cross-cutting config.

## Why

#675's cache key was over-engineered, and the post-merge logs (`venv-v1-Linux---py3.12-…`) make the bug in the safety addition obvious. Trimming the dead bits keeps the working parts and is easier to read.

## Notes

- The post-merge `pycairo` `BadZipFile` failures on `test (3.10–3.13, use_cython)` were a transient PyPI/wheel issue, not caused by #675's caching. Logs show `poetry cache is not found` (setup-python cache missed) and our venv cache also missed on that run — pycairo's wheel was downloaded fresh and the download landed corrupt. Out of scope for this PR; a rerun should clear it.
- If runner-image-flip safety becomes desirable later, it needs to be done via a `run:` step that reads `$ImageVersion` from the shell and exposes it as a step output — the bare `${{ env.ImageVersion }}` reference is silently empty. Worth a separate PR if we decide we want it.
