### PR TITLE
docs(contributing): fix grammar in submit-feedback line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ dbus-fast could always use more documentation, whether as part of the official d
 
 ### Submit Feedback
 
-The best way to send feedback [our issue page][gh-issues] on GitHub. If you are proposing a feature:
+The best way to send feedback is via [our issue page][gh-issues] on GitHub. If you are proposing a feature:
 
 - Explain in detail how it would work.
 - Keep the scope as narrow as possible, to make it easier to implement.


### PR DESCRIPTION
## What

Fixes a tiny grammar nit in `CONTRIBUTING.md` ("The best way to send feedback our issue page" → "is via our issue page").

## Why

The actual goal of this PR is to verify the caching layers added in #674, #675, #676, and #679 hit on a real PR that doesn't invalidate any of the cache keys. The change has to touch *something* to trigger CI — `CONTRIBUTING.md` is outside every key in the workflow, so this is a free verification run.

## What to check in the CI logs

- **`Install libs` step** (test + benchmark): should show `Cache hit for: cache-apt-pkgs_…` and skip `apt-get update`.
- **`Cache poetry venv` step** (test + benchmark): should show `Cache hit for: venv-v1-Linux-py<ver>-<extension>-<hash>` and the `Install Dependencies` step should be skipped (its `if: steps.cache-venv.outputs.cache-hit != 'true'` evaluates to false).
- **`Cache s390x apt + uv downloads` step** (s390x): should show `Cache hit for: s390x-deps-v1-<hash>`.

If those three show hits and tests still pass, the caching is doing what we designed for. If anything misses unexpectedly, the key-construction logic needs another look.

Merging this PR is fine (it's a real grammar fix); the verification value is in the CI log either way.
