### PR TITLE
ci: retry poetry install to absorb transient pypi flakes

### DIFF
--- a/.github/actions/poetry-install/action.yml
+++ b/.github/actions/poetry-install/action.yml
@@ -1,0 +1,33 @@
+name: Install poetry deps with retry
+description: >
+  Run `poetry install --only=main,dev` with a retry loop so transient
+  PyPI flakes (for example BadZipFile in poetry's isolated build env
+  for pygobject) don't fail the job on the first attempt.
+
+inputs:
+  extension:
+    description: Either "skip_cython" or "use_cython".
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Dependencies
+      shell: bash
+      env:
+        EXTENSION: ${{ inputs.extension }}
+      run: |
+        if [ "$EXTENSION" = "skip_cython" ]; then
+          export SKIP_CYTHON=1
+        else
+          export REQUIRE_CYTHON=1
+        fi
+        for attempt in 1 2 3; do
+          if poetry install --only=main,dev; then
+            exit 0
+          fi
+          echo "::warning::poetry install failed on attempt $attempt; retrying"
+          sleep $((attempt * 5))
+        done
+        echo "::error::poetry install failed after 3 attempts"
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,9 @@ jobs:
           key: venv-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/dbus_fast/**/*.py', 'src/dbus_fast/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          if [ "${{ matrix.extension }}" = "skip_cython" ]; then
-            SKIP_CYTHON=1 poetry install --only=main,dev
-          else
-            REQUIRE_CYTHON=1 poetry install --only=main,dev
-          fi
+        uses: ./.github/actions/poetry-install
+        with:
+          extension: ${{ matrix.extension }}
       - name: Test with Pytest
         run: dbus-run-session -- poetry run pytest --cov-report=xml --timeout=5 --durations=30 --ignore=tests/benchmarks
       - name: Upload coverage to Codecov
@@ -167,9 +164,9 @@ jobs:
           key: venv-v1-${{ runner.os }}-benchmark-py3.14-${{ hashFiles('poetry.lock', 'pyproject.toml', 'build_ext.py', 'src/dbus_fast/**/*.py', 'src/dbus_fast/**/*.pxd') }}
       - name: Install Dependencies
         if: steps.cache-venv.outputs.cache-hit != 'true'
-        run: |
-          REQUIRE_CYTHON=1 poetry install --only=main,dev
-        shell: bash
+        uses: ./.github/actions/poetry-install
+        with:
+          extension: use_cython
       - name: Run benchmarks
         uses: CodSpeedHQ/action@c381be0bfd20e844fb45594f6aa182ffcd94545c # v4.15.0
         with:


### PR DESCRIPTION
Sometimes `poetry install` fails in the test matrix when poetry's isolated build env for pygobject downloads a corrupt pycairo wheel from PyPI (`BadZipFile`); this adds a small composite action that retries `poetry install` up to three times with backoff, and wires both the test matrix and the benchmark job through it so the retry logic lives in one place.

Example flake: run 26113443748, the 3.12 skip_cython job.
