### PR TITLE
ci: build armv7l wheels on native ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,49 @@ jobs:
         include:
           # qemu is slow, make a single runner per Python version
           - {
+              os: ubuntu-24.04-arm,
+              qemu: armv7l,
+              musl: "musllinux",
+              pyver: cp310,
+            }
+          - {
+              os: ubuntu-24.04-arm,
+              qemu: armv7l,
+              musl: "musllinux",
+              pyver: cp311,
+            }
+          - {
+              os: ubuntu-24.04-arm,
+              qemu: armv7l,
+              musl: "musllinux",
+              pyver: cp312,
+            }
+          - {
+              os: ubuntu-24.04-arm,
+              qemu: armv7l,
+              musl: "musllinux",
+              pyver: cp313,
+            }
+          - {
+              os: ubuntu-24.04-arm,
+              qemu: armv7l,
+              musl: "musllinux",
+              pyver: cp314,
+            }
+          - {
+              os: ubuntu-24.04-arm,
+              qemu: armv7l,
+              musl: "musllinux",
+              pyver: cp314t,
+            }
+          - { os: ubuntu-24.04-arm, qemu: armv7l, musl: "", pyver: cp310 }
+          - { os: ubuntu-24.04-arm, qemu: armv7l, musl: "", pyver: cp311 }
+          - { os: ubuntu-24.04-arm, qemu: armv7l, musl: "", pyver: cp312 }
+          - { os: ubuntu-24.04-arm, qemu: armv7l, musl: "", pyver: cp313 }
+          - { os: ubuntu-24.04-arm, qemu: armv7l, musl: "", pyver: cp314 }
+          - { os: ubuntu-24.04-arm, qemu: armv7l, musl: "", pyver: cp314t }
+          # qemu is slow, make a single runner per Python version
+          - {
               os: ubuntu-latest,
               qemu: riscv64,
               musl: "musllinux",


### PR DESCRIPTION
Add armv7l wheel builds on `ubuntu-24.04-arm`, matching the layout python-zeroconf landed in python-zeroconf/python-zeroconf#1741. QEMU is still used for the 32 bit ARM binfmt handler, but running on a native aarch64 host is far cheaper than emulating armv7l on x86_64.

riscv64 stays on `ubuntu-latest` since there is no native GH hosted runner for it.
