### PR TITLE
docs: add PSR insertion-flag marker to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+<!-- version list -->
 
 ## Unreleased
 


### PR DESCRIPTION
Follow-up to #688; PSR v10 defaults to `mode = "update"` and scans for `<!-- version list -->` as the insertion anchor, so without that marker the changelog silently stops updating, which is what happened originally.

This adds the marker right under the `# CHANGELOG` header to match PSR's default template, so future releases land here automatically.
