### PR TITLE
test: drop blocking sendall in auth_readline peer-side setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,6 @@ addopts = "-v --cov=dbus_fast --cov-report=term-missing:skip-covered"
 pythonpath = ["src"]
 filterwarnings = [
     "error",
-    # Two auth_readline tests xfail on a blocking socket.sendall in their
-    # peer-side setup; the server socket leaks when setup raises and its
-    # finalizer escalates ResourceWarning via pytest unraisable. Remove once
-    # tests/conftest.py::_KNOWN_BLOCKING is empty.
-    "ignore::pytest.PytestUnraisableExceptionWarning",
-    "ignore::ResourceWarning",
     '''ignore:The global interpreter lock \(GIL\) has been enabled to load module 'gi\._gi'.*:RuntimeWarning''',
     # PyGObject 3.56's gi.events module uses the asyncio event loop policy API
     # (AbstractEventLoopPolicy, get_event_loop_policy, ...) which Python 3.14

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,15 +34,7 @@ _BENCHMARKS_DIR = "tests/benchmarks"
 # Tests that perform sync IO inside the asyncio event loop and trip
 # blockbuster. Marked xfail so CI is green; pop entries as they get
 # fixed so the underlying blocking call is gone for good.
-_KNOWN_BLOCKING: frozenset[str] = frozenset(
-    {
-        # Test peer sockets simulating the dbus daemon side use a blocking
-        # socket.sendall in test setup; not a production bug. Switch the
-        # tests to loop.sock_sendall to clear these.
-        "tests/test_auth_readline.py::test_auth_readline_rejects_oversize_line",
-        "tests/test_auth_readline.py::test_auth_readline_returns_line",
-    }
-)
+_KNOWN_BLOCKING: frozenset[str] = frozenset()
 
 
 def pytest_collection_modifyitems(

--- a/tests/test_auth_readline.py
+++ b/tests/test_auth_readline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import socket
 from types import SimpleNamespace
 
@@ -48,6 +49,8 @@ async def test_auth_readline_rejects_oversize_line() -> None:
                 await asyncio.wait_for(coro, timeout=1.0)
         finally:
             writer.cancel()
+            with contextlib.suppress(asyncio.CancelledError, OSError):
+                await writer
     finally:
         server.close()
         client.close()
@@ -60,11 +63,11 @@ async def test_auth_readline_returns_line() -> None:
         client.setblocking(False)
         server.setblocking(False)
         await asyncio.get_running_loop().sock_sendall(server, b"OK 1234\r\n")
-        server.close()
 
         line = await asyncio.wait_for(
             MessageBus._auth_readline(_fake_aio_self(client)), timeout=1.0
         )
         assert line == "OK 1234"
     finally:
+        server.close()
         client.close()

--- a/tests/test_auth_readline.py
+++ b/tests/test_auth_readline.py
@@ -35,16 +35,21 @@ async def test_auth_readline_rejects_oversize_line() -> None:
     server, client = socket.socketpair()
     try:
         client.setblocking(False)
-        server.setblocking(True)
+        server.setblocking(False)
         # Stream junk that never contains \r\n; cap is 16 KiB so 64 KiB is
-        # well past the limit but small enough to fit a socket buffer.
-        server.sendall(b"A" * 64 * 1024)
-        server.close()
-
-        coro = MessageBus._auth_readline(_fake_aio_self(client))
-        with pytest.raises(AuthError):
-            await asyncio.wait_for(coro, timeout=1.0)
+        # well past the limit. Drive the send from a background task so the
+        # peer write progresses as the reader drains, regardless of the
+        # socketpair send buffer size.
+        loop = asyncio.get_running_loop()
+        writer = asyncio.create_task(loop.sock_sendall(server, b"A" * 64 * 1024))
+        try:
+            coro = MessageBus._auth_readline(_fake_aio_self(client))
+            with pytest.raises(AuthError):
+                await asyncio.wait_for(coro, timeout=1.0)
+        finally:
+            writer.cancel()
     finally:
+        server.close()
         client.close()
 
 
@@ -53,8 +58,8 @@ async def test_auth_readline_returns_line() -> None:
     server, client = socket.socketpair()
     try:
         client.setblocking(False)
-        server.setblocking(True)
-        server.sendall(b"OK 1234\r\n")
+        server.setblocking(False)
+        await asyncio.get_running_loop().sock_sendall(server, b"OK 1234\r\n")
         server.close()
 
         line = await asyncio.wait_for(


### PR DESCRIPTION
The two `tests/test_auth_readline.py` cases set up their peer socket with a blocking `socket.sendall`, which blockbuster catches even though it is test-only and not a production bug. Switched both peers to non-blocking and drove the writes via `loop.sock_sendall`; the 64 KiB junk-line test runs sendall as a background task so the write progresses concurrently with the reader and does not deadlock when the socketpair send buffer is small.

Cleared `_KNOWN_BLOCKING` and dropped the `PytestUnraisableExceptionWarning` and `ResourceWarning` ignores from filterwarnings; no xfails remain.
