### PR TITLE
fix(aio): send Hello via sock_sendall instead of buffered stream.write

### DIFF
--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -325,8 +325,10 @@ class MessageBus(BaseMessageBus):
                 serialized = HELLO_1_SERIALIZED
             else:
                 serialized = _generate_hello_serialized(next_serial)
-            self._stream.write(serialized)
-            self._stream.flush()
+            # Send Hello via sock_sendall instead of the buffered stream so
+            # we don't perform synchronous BufferedWriter.write() in an async
+            # context. aio writes never go through the stream at runtime.
+            await self._loop.sock_sendall(self._sock, serialized)
             return await future
         except BaseException:
             self._loop.remove_reader(self._fd)
@@ -604,7 +606,6 @@ class MessageBus(BaseMessageBus):
                 await self._loop.sock_sendall(
                     self._sock, Authenticator._format_line(response)
                 )
-                self._stream.flush()
             if response == "BEGIN":
                 # The first octet received by the server after the \r\n of the BEGIN command
                 # from the client must be the first octet of the authenticated/encrypted stream


### PR DESCRIPTION
## Summary

`aio.MessageBus.connect()` ended its handshake by writing the initial Hello via the buffered `sock.makefile(\"rwb\")` stream:

```python
self._stream.write(serialized)
self._stream.flush()
```

Those are synchronous `BufferedWriter` operations and constitute blocking I/O on the event loop. Authentication and runtime writes already bypass the buffered stream (`loop.sock_sendall` / raw `sock.send`); the Hello write was the only outlier.

Send the Hello via `await self._loop.sock_sendall(self._sock, serialized)` to match the rest of the path.

Also drops a dead `self._stream.flush()` after each `sock_sendall` in `_authenticate()`. Auth writes go through `sock_sendall`, so the stream's buffer is always empty there — the flush was a no-op (and had the same blocking-I/O hazard). This line has been dead since the initial port from `python-dbus-next` in 2022.

## How this was caught

Home Assistant Supervisor wraps its event loop with [blockbuster][bb], which intercepts known-blocking calls and raises if any fire from an async context. After upgrading to dbus-fast 5.0.0 (#570 / #569), Supervisor still tripped on this remaining blocking call:

```
File \"/usr/local/lib/python3.14/site-packages/dbus_fast/aio/message_bus.py\", line 328, in connect
    self._stream.write(serialized)
blockbuster.blockbuster.BlockingError: Blocking call to io.BufferedWriter.write
```

#570 deferred `socket.connect()` from `__init__` into `connect()`; this PR finishes the job by removing the last synchronous I/O on the connect path.

## Test plan

- [x] Existing tests pass (31 tests across `test_message_bus`, `test_disconnect`, `test_aio_low_level`, `test_tcp_address`, `test_send_reply`, `test_aio_multi_flags`, `test_auth`).
- [x] Reproduced the blockbuster `BlockingError` on `main`, verified the fix resolves it (connected against the real system bus under `BlockBuster().activate()`).

[bb]: https://pypi.org/project/blockbuster/