### PR TITLE
refactor(aio): drop dead self._stream.flush() in _authenticate()

### DIFF
--- a/src/dbus_fast/aio/message_bus.py
+++ b/src/dbus_fast/aio/message_bus.py
@@ -603,7 +603,6 @@ class MessageBus(BaseMessageBus):
                 await self._loop.sock_sendall(
                     self._sock, Authenticator._format_line(response)
                 )
-                self._stream.flush()
             if response == "BEGIN":
                 # The first octet received by the server after the \r\n of the BEGIN command
                 # from the client must be the first octet of the authenticated/encrypted stream


### PR DESCRIPTION
## Summary

`_authenticate()` calls `self._stream.flush()` after each `await self._loop.sock_sendall(self._sock, Authenticator._format_line(response))`. Auth writes go through `sock_sendall` on the raw socket, so the buffered stream's buffer is always empty when this flush runs — the call has been a no-op since the initial port in 2022.

Drop the line. No behaviour change.

## Context

Spotted while looking at the same `_authenticate()` block for #691. That PR removed the buffered-stream Hello write in `connect()`; this PR removes the matching dead flush in `_authenticate()` for consistency.

## Test plan

- [x] Existing tests pass (`test_message_bus`, `test_auth`, `test_aio_low_level`, `test_disconnect` — 24 tests).
- [x] Connected against the real system bus to verify auth still completes.