### PR TITLE
fix(introspection): bound <node> nesting depth to prevent DoS

### DIFF
--- a/src/dbus_fast/introspection.py
+++ b/src/dbus_fast/introspection.py
@@ -532,10 +532,7 @@ class Node:
 
     @staticmethod
     def from_xml(
-        element: ET.Element,
-        is_root: bool = False,
-        validate_property_names: bool = True,
-        _depth: int = 0,
+        element: ET.Element, is_root: bool = False, validate_property_names: bool = True
     ) -> "Node":
         """Convert an :class:`xml.etree.ElementTree.Element` to a :class:`Node`.
 
@@ -551,11 +548,20 @@ class Node:
         :raises:
             - :class:`InvalidIntrospectionError <dbus_fast.InvalidIntrospectionError>` - If the XML tree is not valid introspection data.
         """
+        return Node._from_xml(element, is_root, validate_property_names, 0)
+
+    @staticmethod
+    def _from_xml(
+        element: ET.Element,
+        is_root: bool,
+        validate_property_names: bool,
+        depth: int,
+    ) -> "Node":
         # Real D-Bus object paths are at most a handful of components deep;
         # 32 is well above any plausible legitimate nesting and keeps a
         # hostile peer from exhausting the Python (or C) stack via a
         # `<node><node>...</node></node>` payload.
-        if _depth > _MAX_NODE_DEPTH:
+        if depth > _MAX_NODE_DEPTH:
             raise InvalidIntrospectionError(
                 f"introspection node nesting exceeds {_MAX_NODE_DEPTH} levels"
             )
@@ -571,10 +577,11 @@ class Node:
                 )
             elif child.tag == "node":
                 node.nodes.append(
-                    Node.from_xml(
+                    Node._from_xml(
                         child,
-                        validate_property_names=validate_property_names,
-                        _depth=_depth + 1,
+                        False,
+                        validate_property_names,
+                        depth + 1,
                     )
                 )
 

--- a/src/dbus_fast/introspection.py
+++ b/src/dbus_fast/introspection.py
@@ -8,6 +8,8 @@ from .validators import assert_interface_name_valid, assert_member_name_valid
 
 # https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format
 
+_MAX_NODE_DEPTH = 32
+
 
 def _reject_internal_subset(
     _name: str,
@@ -530,7 +532,10 @@ class Node:
 
     @staticmethod
     def from_xml(
-        element: ET.Element, is_root: bool = False, validate_property_names: bool = True
+        element: ET.Element,
+        is_root: bool = False,
+        validate_property_names: bool = True,
+        _depth: int = 0,
     ) -> "Node":
         """Convert an :class:`xml.etree.ElementTree.Element` to a :class:`Node`.
 
@@ -546,6 +551,15 @@ class Node:
         :raises:
             - :class:`InvalidIntrospectionError <dbus_fast.InvalidIntrospectionError>` - If the XML tree is not valid introspection data.
         """
+        # Real D-Bus object paths are at most a handful of components deep;
+        # 32 is well above any plausible legitimate nesting and keeps a
+        # hostile peer from exhausting the Python (or C) stack via a
+        # `<node><node>...</node></node>` payload.
+        if _depth > _MAX_NODE_DEPTH:
+            raise InvalidIntrospectionError(
+                f"introspection node nesting exceeds {_MAX_NODE_DEPTH} levels"
+            )
+
         node = Node(element.attrib.get("name"), is_root=is_root)
 
         for child in element:
@@ -558,7 +572,9 @@ class Node:
             elif child.tag == "node":
                 node.nodes.append(
                     Node.from_xml(
-                        child, validate_property_names=validate_property_names
+                        child,
+                        validate_property_names=validate_property_names,
+                        _depth=_depth + 1,
                     )
                 )
 

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -238,3 +238,23 @@ def test_introspection_rejects_default_namespaced_root() -> None:
     payload = '<node xmlns="urn:example"><interface name="a"/></node>'
     with pytest.raises(InvalidIntrospectionError, match="node"):
         intr.Node.parse(payload)
+
+
+def test_introspection_rejects_deeply_nested_nodes() -> None:
+    """Deeply nested <node> elements are bounded to avoid stack exhaustion."""
+    depth = intr._MAX_NODE_DEPTH + 8
+    payload = "<node>" + ('<node name="x">' * depth) + ("</node>" * depth) + "</node>"
+    with pytest.raises(InvalidIntrospectionError, match="nesting"):
+        intr.Node.parse(payload)
+
+
+def test_introspection_accepts_nesting_up_to_cap() -> None:
+    """Nesting up to the cap parses without raising."""
+    depth = intr._MAX_NODE_DEPTH
+    payload = "<node>" + ('<node name="x">' * depth) + ("</node>" * depth) + "</node>"
+    node = intr.Node.parse(payload)
+    cursor = node
+    for _ in range(depth):
+        assert len(cursor.nodes) == 1
+        cursor = cursor.nodes[0]
+    assert cursor.nodes == []


### PR DESCRIPTION
`Node.from_xml` recursed into each child `<node>` with no depth bound, so a peer that controls an Introspect reply could send `<node><node>...</node></node>` deep enough to blow the stack on the client. Real object paths are only a handful of components deep; this caps recursion at 32 and raises `InvalidIntrospectionError` past that.

Fixes #696
