### PR TITLE
fix(unmarshaller): cap container nesting depth to prevent stack overflow DoS

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.pxd
+++ b/src/dbus_fast/_private/unmarshaller.pxd
@@ -24,6 +24,7 @@ cdef unsigned int LITTLE_ENDIAN
 cdef unsigned int BIG_ENDIAN
 cdef unsigned int PROTOCOL_VERSION
 cdef unsigned int _MAX_MESSAGE_SIZE
+cdef unsigned int _MAX_CONTAINER_DEPTH
 
 
 cdef unsigned int HEADER_PATH_IDX
@@ -154,6 +155,7 @@ cdef class Unmarshaller:
     cdef bint _negotiate_unix_fd
     cdef bint _read_complete
     cdef unsigned int _endian
+    cdef unsigned int _container_depth
 
     @cython.locals(to_clear=Py_ssize_t)
     cdef _next_message(self)
@@ -208,7 +210,7 @@ cdef class Unmarshaller:
         token_as_int=cython.uint,
         signature_len=cython.uint,
         o=cython.ulong,
-        var=Variant,
+        result=Variant,
     )
     cdef Variant _read_variant(self)
 

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -581,6 +581,18 @@ class Unmarshaller:
         # *after* any recursive read_array / self._readers[...] call, so an
         # attacker can't pop the counter back to zero between siblings of a
         # deeply nested variant. The pxd declares `result=Variant`.
+        #
+        # Inline += / -= rather than try/finally: try/finally in Cython
+        # compiles to setjmp-style cleanup that lands on the hot path,
+        # while a cdef unsigned int decrement is score-0 C. Skipping the
+        # decrement on the error path is safe because the only recoverable
+        # exception here is the BlockingIOError raised by _read_to_pos
+        # *before* any container reader runs; every other mid-parse error
+        # (IndexError, InvalidMessageError) means the message is corrupt
+        # and the bus connection tears down. As a backstop, _read_body
+        # resets _container_depth to 0 at the start of every message so a
+        # stale counter cannot leak across messages. The same pattern
+        # repeats in read_array, read_struct, and read_dict_entry.
         self._container_depth += 1
         if self._container_depth > _MAX_CONTAINER_DEPTH:
             raise InvalidMessageError(
@@ -589,7 +601,7 @@ class Unmarshaller:
         if cython.compiled:
             if self._buf_len <= self._pos:
                 raise IndexError("Not enough data to read signature")
-        result = None
+        result: Variant | None = None
         signature_len = self._buf_ustr[self._pos]
         if signature_len == 1:
             self._pos += 3  # 1 len byte + 1 signature char + 1 null terminator

--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -86,6 +86,20 @@ HEADER_ARRAY_OF_STRUCT_SIGNATURE_POSITION = 12
 MAX_MESSAGE_SIZE = 134_217_728
 _MAX_MESSAGE_SIZE = MAX_MESSAGE_SIZE
 
+# D-Bus spec sec 4.4 caps signature container nesting at 32 array + 32 struct
+# levels. Variants carry their own signature, so a variant containing a
+# variant containing... re-enters the reader at each level and bypasses that
+# per-signature limit. A 128 MiB message can pack ~40 million variant levels
+# (signature_len byte + 'v' + null = 3 bytes per level) and overflow the
+# Python C-recursion stack before the existing size cap saves us. Bound the
+# runtime container nesting across variants, arrays, structs, and dict
+# entries at the same 64 the spec already implies for any single signature.
+#
+# MAX_CONTAINER_DEPTH is the Python-importable form (used by tests);
+# _MAX_CONTAINER_DEPTH is the cdef unsigned int form used internally per .pxd.
+MAX_CONTAINER_DEPTH = 64
+_MAX_CONTAINER_DEPTH = MAX_CONTAINER_DEPTH
+
 
 # Most common signatures
 
@@ -289,6 +303,7 @@ class Unmarshaller:
         "_buf",
         "_buf_len",
         "_buf_ustr",
+        "_container_depth",
         "_endian",
         "_flag",
         "_header_len",
@@ -339,6 +354,7 @@ class Unmarshaller:
         self._uint16_unpack: Callable[[bytearray, int], tuple[int]] | None = None
         self._negotiate_unix_fd = negotiate_unix_fd
         self._read_complete = False
+        self._container_depth = 0
         if stream:
             if isinstance(stream, io.BufferedRWPair) and hasattr(stream, "reader"):
                 self._stream_reader = stream.reader.read
@@ -371,6 +387,7 @@ class Unmarshaller:
             self._buf_ustr = self._buf
         self._msg_len = 0  # used to check if we have ready the header
         self._read_complete = False  # used to check if we have ready the message
+        self._container_depth = 0
         # No need to reset the unpack functions, they are set in _read_header
         # every time a new message is processed.
 
@@ -558,9 +575,21 @@ class Unmarshaller:
         # Inline signature reading to avoid _read_signature() call,
         # .decode(), and ord() for the common single-byte case.
         # verify in Variant is only useful on construction not unmarshalling
+        #
+        # Single-return shape: every branch assigns `result`, then we
+        # decrement and return once at the bottom. The decrement has to come
+        # *after* any recursive read_array / self._readers[...] call, so an
+        # attacker can't pop the counter back to zero between siblings of a
+        # deeply nested variant. The pxd declares `result=Variant`.
+        self._container_depth += 1
+        if self._container_depth > _MAX_CONTAINER_DEPTH:
+            raise InvalidMessageError(
+                f"container nesting exceeds maximum {_MAX_CONTAINER_DEPTH}"
+            )
         if cython.compiled:
             if self._buf_len <= self._pos:
                 raise IndexError("Not enough data to read signature")
+        result = None
         signature_len = self._buf_ustr[self._pos]
         if signature_len == 1:
             self._pos += 3  # 1 len byte + 1 signature char + 1 null terminator
@@ -569,23 +598,28 @@ class Unmarshaller:
                     raise IndexError("Not enough data to read signature")
             token_as_int = self._buf_ustr[self._pos - 2]
             if token_as_int == TOKEN_N_AS_INT:
-                return Variant._factory(SIGNATURE_TREE_N, self._read_int16_unpack())
-            if token_as_int == TOKEN_S_AS_INT:
-                return Variant._factory(SIGNATURE_TREE_S, self._read_string_unpack())
-            if token_as_int == TOKEN_B_AS_INT:
-                return VARIANT_BOOL_TRUE if self._read_boolean() else VARIANT_BOOL_FALSE
-            if token_as_int == TOKEN_O_AS_INT:
-                return Variant._factory(SIGNATURE_TREE_O, self._read_string_unpack())
-            if token_as_int == TOKEN_U_AS_INT:
-                return Variant._factory(SIGNATURE_TREE_U, self._read_uint32_unpack())
-            if token_as_int == TOKEN_Y_AS_INT:
+                result = Variant._factory(SIGNATURE_TREE_N, self._read_int16_unpack())
+            elif token_as_int == TOKEN_S_AS_INT:
+                result = Variant._factory(SIGNATURE_TREE_S, self._read_string_unpack())
+            elif token_as_int == TOKEN_B_AS_INT:
+                result = (
+                    VARIANT_BOOL_TRUE if self._read_boolean() else VARIANT_BOOL_FALSE
+                )
+            elif token_as_int == TOKEN_O_AS_INT:
+                result = Variant._factory(SIGNATURE_TREE_O, self._read_string_unpack())
+            elif token_as_int == TOKEN_U_AS_INT:
+                result = Variant._factory(SIGNATURE_TREE_U, self._read_uint32_unpack())
+            elif token_as_int == TOKEN_Y_AS_INT:
                 self._pos += 1
                 if cython.compiled:
                     if self._buf_len < self._pos:
                         raise IndexError("Not enough data to read byte")
-                return Variant._factory(SIGNATURE_TREE_Y, self._buf_ustr[self._pos - 1])
-            # Uncommon single-byte type, decode for fallback
-            signature = chr(token_as_int)
+                result = Variant._factory(
+                    SIGNATURE_TREE_Y, self._buf_ustr[self._pos - 1]
+                )
+            else:
+                # Uncommon single-byte type, decode for fallback
+                signature = chr(token_as_int)
         else:
             o = self._pos + 1
             self._pos = o + signature_len + 1
@@ -594,47 +628,73 @@ class Unmarshaller:
                     raise IndexError("Not enough data to read signature")
             signature = self._buf_ustr[o : o + signature_len].decode()
             token_as_int = self._buf_ustr[o]
-        if token_as_int == TOKEN_A_AS_INT:
-            if signature == "ay":
-                return Variant._factory(
-                    SIGNATURE_TREE_AY, self.read_array(SIGNATURE_TREE_AY_TYPES_0)
+        if result is None:
+            if token_as_int == TOKEN_A_AS_INT:
+                if signature == "ay":
+                    result = Variant._factory(
+                        SIGNATURE_TREE_AY, self.read_array(SIGNATURE_TREE_AY_TYPES_0)
+                    )
+                elif signature == "a{qv}":
+                    result = Variant._factory(
+                        SIGNATURE_TREE_A_QV,
+                        self.read_array(SIGNATURE_TREE_A_QV_TYPES_0),
+                    )
+                elif signature == "as":
+                    result = Variant._factory(
+                        SIGNATURE_TREE_AS, self.read_array(SIGNATURE_TREE_AS_TYPES_0)
+                    )
+                elif signature == "a{sv}":
+                    result = Variant._factory(
+                        SIGNATURE_TREE_A_SV,
+                        self.read_array(SIGNATURE_TREE_A_SV_TYPES_0),
+                    )
+                elif signature == "ao":
+                    result = Variant._factory(
+                        SIGNATURE_TREE_AO, self.read_array(SIGNATURE_TREE_AO_TYPES_0)
+                    )
+            if result is None:
+                tree = get_signature_tree(signature)
+                signature_type = tree.root_type
+                result = Variant._factory(
+                    tree, self._readers[signature_type.token](self, signature_type)
                 )
-            if signature == "a{qv}":
-                return Variant._factory(
-                    SIGNATURE_TREE_A_QV, self.read_array(SIGNATURE_TREE_A_QV_TYPES_0)
-                )
-            if signature == "as":
-                return Variant._factory(
-                    SIGNATURE_TREE_AS, self.read_array(SIGNATURE_TREE_AS_TYPES_0)
-                )
-            if signature == "a{sv}":
-                return Variant._factory(
-                    SIGNATURE_TREE_A_SV, self.read_array(SIGNATURE_TREE_A_SV_TYPES_0)
-                )
-            if signature == "ao":
-                return Variant._factory(
-                    SIGNATURE_TREE_AO, self.read_array(SIGNATURE_TREE_AO_TYPES_0)
-                )
-        tree = get_signature_tree(signature)
-        signature_type = tree.root_type
-        return Variant._factory(
-            tree, self._readers[signature_type.token](self, signature_type)
-        )
+        self._container_depth -= 1
+        return result
 
     def read_struct(self, type_: _SignatureType) -> tuple[Any, ...]:
+        self._container_depth += 1
+        if self._container_depth > _MAX_CONTAINER_DEPTH:
+            raise InvalidMessageError(
+                f"container nesting exceeds maximum {_MAX_CONTAINER_DEPTH}"
+            )
         self._pos += -self._pos & 7  # align 8
         readers = self._readers
-        return tuple(
+        result = tuple(
             readers[child_type.token](self, child_type) for child_type in type_.children
         )
+        self._container_depth -= 1
+        return result
 
     def read_dict_entry(self, type_: _SignatureType) -> tuple[Any, Any]:
+        self._container_depth += 1
+        if self._container_depth > _MAX_CONTAINER_DEPTH:
+            raise InvalidMessageError(
+                f"container nesting exceeds maximum {_MAX_CONTAINER_DEPTH}"
+            )
         self._pos += -self._pos & 7  # align 8
-        return self._readers[type_.children[0].token](
-            self, type_.children[0]
-        ), self._readers[type_.children[1].token](self, type_.children[1])
+        key = self._readers[type_.children[0].token](self, type_.children[0])
+        value = self._readers[type_.children[1].token](self, type_.children[1])
+        self._container_depth -= 1
+        return key, value
 
     def read_array(self, type_: _SignatureType) -> Iterable[Any]:
+        # Single-return shape so the depth decrement runs once at the bottom,
+        # after any recursive read_* call has popped its own frame.
+        self._container_depth += 1
+        if self._container_depth > _MAX_CONTAINER_DEPTH:
+            raise InvalidMessageError(
+                f"container nesting exceeds maximum {_MAX_CONTAINER_DEPTH}"
+            )
         self._pos += -self._pos & 3  # align 4 for the array
         self._pos += (
             -self._pos & (UINT32_SIZE - 1)
@@ -665,9 +725,8 @@ class Unmarshaller:
             if cython.compiled:
                 if self._buf_len < self._pos:
                     raise IndexError("Not enough data to read byte")
-            return self._buf_ustr[self._pos - array_length : self._pos]
-
-        if token_as_int == TOKEN_LEFT_CURLY_AS_INT:
+            result = self._buf_ustr[self._pos - array_length : self._pos]
+        elif token_as_int == TOKEN_LEFT_CURLY_AS_INT:
             result_dict: dict[Any, Any] = {}
             key: str | int
             beginning_pos = self._pos
@@ -709,22 +768,22 @@ class Unmarshaller:
                     self._pos += -self._pos & 7  # align 8
                     key = reader_0(self, child_0)
                     result_dict[key] = reader_1(self, child_1)
-
-            return result_dict
-
-        if array_length == 0:
-            return []
-
-        result_list = []
-        beginning_pos = self._pos
-        if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:
-            while self._pos - beginning_pos < array_length:
-                result_list.append(self._read_string_unpack())
-            return result_list
-        reader = self._readers[child_type.token]
-        while self._pos - beginning_pos < array_length:
-            result_list.append(reader(self, child_type))
-        return result_list
+            result = result_dict
+        elif array_length == 0:
+            result = []
+        else:
+            result_list = []
+            beginning_pos = self._pos
+            if token_as_int == TOKEN_O_AS_INT or token_as_int == TOKEN_S_AS_INT:
+                while self._pos - beginning_pos < array_length:
+                    result_list.append(self._read_string_unpack())
+            else:
+                reader = self._readers[child_type.token]
+                while self._pos - beginning_pos < array_length:
+                    result_list.append(reader(self, child_type))
+            result = result_list
+        self._container_depth -= 1
+        return result
 
     def _header_fields(self, header_length: _int) -> list[Any]:
         """Header fields are always a(yv)."""
@@ -828,6 +887,7 @@ class Unmarshaller:
         """Read the body of the message."""
         self._read_to_pos(HEADER_SIGNATURE_SIZE + self._msg_len)
         self._pos = HEADER_ARRAY_OF_STRUCT_SIGNATURE_POSITION
+        self._container_depth = 0
         header_fields = self._header_fields(self._header_len)
         self._pos += -self._pos & 7  # align 8
         signature: str = header_fields[HEADER_SIGNATURE_IDX]

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -11,6 +11,7 @@ from dbus_fast import Message, MessageFlag, MessageType, SignatureTree, Variant
 from dbus_fast._private._cython_compat import FakeCython
 from dbus_fast._private.constants import BIG_ENDIAN, LITTLE_ENDIAN
 from dbus_fast._private.unmarshaller import (
+    MAX_CONTAINER_DEPTH,
     MAX_MESSAGE_SIZE,
     Unmarshaller,
     buffer_to_int16,
@@ -1015,3 +1016,79 @@ def test_unmarshall_rejects_max_uint32_body_len_big_endian() -> None:
     forged = _forged_header(body_len=0xFFFFFFFF, header_len=0, endian=">")
     with pytest.raises(InvalidMessageError, match="exceeds maximum"):
         Unmarshaller(io.BytesIO(forged)).unmarshall()
+
+
+def _replace_body(template: bytearray, new_body: bytes) -> bytes:
+    """Swap a `v`-signature message's body bytes and fix up body_len."""
+    header_len = struct.unpack_from("<I", template, 12)[0]
+    pad = (-header_len) & 7
+    body_start = 16 + header_len + pad
+    result = bytearray(template[:body_start])
+    result.extend(new_body)
+    struct.pack_into("<I", result, 4, len(new_body))
+    return bytes(result)
+
+
+def _nested_variant_body(depth: int) -> bytes:
+    """Wire bytes for `depth` levels of variant-in-variant ending in a 'y' byte."""
+    body = bytearray()
+    for _ in range(depth - 1):
+        body.extend(b"\x01v\x00")  # signature_len=1, 'v', null
+    body.extend(b"\x01y\x00\x01")  # signature_len=1, 'y', null, value=1
+    return bytes(body)
+
+
+def _build_nested_variant_message(depth: int) -> bytes:
+    template = _build_variant_message(Variant("y", 1))
+    return _replace_body(template, _nested_variant_body(depth))
+
+
+def test_unmarshall_accepts_variant_nesting_at_cap() -> None:
+    """A message right at the cap depth must still parse."""
+    data = _build_nested_variant_message(MAX_CONTAINER_DEPTH)
+    msg = Unmarshaller(io.BytesIO(data)).unmarshall()
+    assert msg is not None
+    # Walk to the innermost byte to confirm full parse.
+    inner = msg.body[0]
+    for _ in range(MAX_CONTAINER_DEPTH - 1):
+        inner = inner.value
+    assert inner.value == 1
+
+
+def test_unmarshall_rejects_variant_nesting_above_cap() -> None:
+    """One past the cap raises InvalidMessageError before the stack blows."""
+    data = _build_nested_variant_message(MAX_CONTAINER_DEPTH + 1)
+    with pytest.raises(InvalidMessageError, match="container nesting exceeds maximum"):
+        Unmarshaller(io.BytesIO(data)).unmarshall()
+
+
+def test_unmarshall_rejects_deeply_nested_variant_dos() -> None:
+    """A million levels of variant-in-variant must be rejected, not crash."""
+    data = _build_nested_variant_message(1_000_000)
+    with pytest.raises(InvalidMessageError, match="container nesting exceeds maximum"):
+        Unmarshaller(io.BytesIO(data)).unmarshall()
+
+
+def test_unmarshall_accepts_many_sibling_variants() -> None:
+    """Many variants at the same depth must not trip the cap (siblings, not nested)."""
+    entries = {f"k{i}": Variant("y", i & 0xFF) for i in range(MAX_CONTAINER_DEPTH * 4)}
+    msg = Message(
+        message_type=MessageType.METHOD_RETURN,
+        reply_serial=1,
+        signature="a{sv}",
+        body=[entries],
+    )
+    marshalled = msg._marshall(False)
+    result = Unmarshaller(io.BytesIO(marshalled)).unmarshall()
+    assert result is not None
+    assert len(result.body[0]) == len(entries)
+
+
+def test_unmarshall_depth_counter_resets_between_messages() -> None:
+    """Two cap-depth messages back-to-back must both parse on the same unmarshaller."""
+    data1 = _build_nested_variant_message(MAX_CONTAINER_DEPTH)
+    data2 = _build_nested_variant_message(MAX_CONTAINER_DEPTH)
+    stream = io.BytesIO(data1 + data2)
+    unmarshaller = Unmarshaller(stream)
+    assert unmarshaller.unmarshall() is not None
+    assert unmarshaller.unmarshall() is not None

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -1031,11 +1031,7 @@ def _replace_body(template: bytearray, new_body: bytes) -> bytes:
 
 def _nested_variant_body(depth: int) -> bytes:
     """Wire bytes for `depth` levels of variant-in-variant ending in a 'y' byte."""
-    body = bytearray()
-    for _ in range(depth - 1):
-        body.extend(b"\x01v\x00")  # signature_len=1, 'v', null
-    body.extend(b"\x01y\x00\x01")  # signature_len=1, 'y', null, value=1
-    return bytes(body)
+    return (b"\x01v\x00" * (depth - 1)) + b"\x01y\x00\x01"
 
 
 def _build_nested_variant_message(depth: int) -> bytes:

--- a/tests/test_marshaller.py
+++ b/tests/test_marshaller.py
@@ -1092,3 +1092,75 @@ def test_unmarshall_depth_counter_resets_between_messages() -> None:
     unmarshaller = Unmarshaller(stream)
     assert unmarshaller.unmarshall() is not None
     assert unmarshaller.unmarshall() is not None
+
+
+def _nested_variants_then_signature(outer_count: int, inner_signature: bytes) -> bytes:
+    """`outer_count` 'v' variant levels then a final variant carrying `inner_signature`.
+
+    The final variant's value bytes are intentionally omitted; the per-reader
+    depth check raises before any value bytes are read.
+    """
+    body = bytearray()
+    for _ in range(outer_count):
+        body.extend(b"\x01v\x00")
+    body.append(len(inner_signature))
+    body.extend(inner_signature)
+    body.append(0)  # null terminator
+    return bytes(body)
+
+
+def test_unmarshall_rejects_struct_nesting_above_cap() -> None:
+    """64 'v' levels wrapping a struct trips read_struct's depth check."""
+    template = _build_variant_message(Variant("y", 1))
+    inner_body = _nested_variants_then_signature(MAX_CONTAINER_DEPTH - 1, b"(y)")
+    data = _replace_body(template, inner_body)
+    with pytest.raises(InvalidMessageError, match="container nesting exceeds maximum"):
+        Unmarshaller(io.BytesIO(data)).unmarshall()
+
+
+def test_unmarshall_rejects_array_nesting_above_cap() -> None:
+    """64 'v' levels wrapping an array trips read_array's depth check."""
+    template = _build_variant_message(Variant("y", 1))
+    inner_body = _nested_variants_then_signature(MAX_CONTAINER_DEPTH - 1, b"ay")
+    data = _replace_body(template, inner_body)
+    with pytest.raises(InvalidMessageError, match="container nesting exceeds maximum"):
+        Unmarshaller(io.BytesIO(data)).unmarshall()
+
+
+def test_unmarshall_rejects_dict_entry_nesting_above_cap() -> None:
+    """64 'v' levels wrapping a {sv} dict entry trips read_dict_entry's depth check."""
+    # `{sv}` parses as a top-level signature, so wrapping it in variants routes
+    # the deepest dispatch through self._readers["{"] = read_dict_entry rather
+    # than the inline `{` handling in read_array.
+    template = _build_variant_message(Variant("y", 1))
+    inner_body = _nested_variants_then_signature(MAX_CONTAINER_DEPTH - 1, b"{sv}")
+    data = _replace_body(template, inner_body)
+    with pytest.raises(InvalidMessageError, match="container nesting exceeds maximum"):
+        Unmarshaller(io.BytesIO(data)).unmarshall()
+
+
+def test_unmarshall_accepts_variant_of_dict_entry() -> None:
+    """A variant carrying a `{sv}` dict entry exercises read_dict_entry's success path."""
+    # Variant._construct rejects `{sv}` as a top-level signature, so we forge
+    # the body bytes directly. Routes the deepest dispatch through
+    # self._readers["{"] = read_dict_entry instead of read_array's inline path.
+    template = _build_variant_message(Variant("y", 1))
+    header_len = struct.unpack_from("<I", template, 12)[0]
+    body_start = 16 + header_len + ((-header_len) & 7)
+
+    new_body = bytearray(b"\x04{sv}\x00")  # variant header for `{sv}`
+    align_pad = (-(body_start + len(new_body))) & 7
+    new_body.extend(b"\x00" * align_pad)
+    new_body.extend(struct.pack("<I", 1))  # key length
+    new_body.extend(b"k\x00")  # key chars + null
+    new_body.extend(b"\x01y\x00\x07")  # value variant of 'y' = 7
+
+    data = _replace_body(template, bytes(new_body))
+    msg = Unmarshaller(io.BytesIO(data)).unmarshall()
+    assert msg is not None
+    outer = msg.body[0]
+    assert outer.signature == "{sv}"
+    key, value = outer.value
+    assert key == "k"
+    assert value.signature == "y"
+    assert value.value == 7


### PR DESCRIPTION
A peer can pack roughly forty million levels of variant-in-variant into a single 128 MiB message, since each level only costs three bytes on the wire (signature_len byte, `v`, null). `_read_variant` and `read_array` recursed into each level and could blow the Python C stack before the existing size cap rejected the message.

The fix adds a single cdef unsigned int depth counter to the `Unmarshaller`, bumped at entry to each container reader (variant, array, struct, dict entry) and decremented before the return, after any recursive call has popped its own frame. If it exceeds 64 (the same limit the D-Bus spec already implies for any single signature, 32 array plus 32 struct), parsing raises `InvalidMessageError` and the connection tears down before the stack overflows.

Verified the Cython HTML for `unmarshaller.html`; the counter ops are score-0 pure C (`__pyx_v_self->_container_depth = (... + 1);` etc.) and the `result is None` check in the refactored `_read_variant` compiles to a pointer compare. The only Python-level code on the new path is the f-string in the reject branch.

Closes #695
