### PR TITLE
test: skip blockbuster on the cython matrix leg

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,15 @@ except ImportError:  # s390x leg skips installing blockbuster under QEMU
     BlockBuster = None  # type: ignore[assignment,misc]
     blockbuster_ctx = None  # type: ignore[assignment]
 
+from dbus_fast._private.unmarshaller import is_compiled
+
+# blockbuster monkey-patches threading.Lock.acquire and walks the frame
+# stack via inspect.getframeinfo. Coverage's CTracer takes that lock on
+# every traced line, and walking a frame whose code object belongs to a
+# Cython extension has segfaulted in CI. The SKIP_CYTHON matrix leg
+# still exercises blockbuster, so blocking-call detection is preserved.
+_RUNNING_COMPILED = is_compiled()
+
 _BENCHMARKS_DIR = "tests/benchmarks"
 
 # Tests that perform sync IO inside the asyncio event loop and trip
@@ -57,7 +66,11 @@ def blockbuster(
     request: pytest.FixtureRequest,
 ) -> Iterator[BlockBuster | None]:
     """Fail any test that performs a blocking call inside the asyncio loop."""
-    if blockbuster_ctx is None or _BENCHMARKS_DIR in str(request.node.fspath):
+    if (
+        blockbuster_ctx is None
+        or _RUNNING_COMPILED
+        or _BENCHMARKS_DIR in str(request.node.fspath)
+    ):
         yield None
         return
     with blockbuster_ctx() as bb:


### PR DESCRIPTION
## What

Skip the autouse `blockbuster` fixture in `tests/conftest.py` when the suite is running against the compiled Cython extension. The `SKIP_CYTHON=1` matrix leg still wraps every test in `blockbuster_ctx()`, so blocking-call detection is preserved.

## Why

The `test (3.11, ubuntu-latest, use_cython)` cell has been segfaulting intermittently across unrelated PRs (e.g. the run on #705, and an earlier run on the `koan/message-size-cap` branch), and same-commit re-runs pass. The faulthandler trace is the same each time:

```
File ".../blockbuster/blockbuster.py", line 81 in wrapper
File ".../coverage/collector.py", line 257 in lock_data
File "src/dbus_fast/_private/util.py", line 167 in <genexpr>
File "src/dbus_fast/_private/util.py", line 167 in _replace_fds
File "src/dbus_fast/_private/util.py", line 77 in replace_fds_with_idx
File "tests/test_fd_passing.py", line 393 in test_fn_result_to_body
```

`blockbuster` monkey-patches `threading.Lock.acquire` and, on every call inside a running event loop, walks the frame stack via `inspect.currentframe()` / `inspect.getframeinfo()`. `coverage`'s CTracer takes the data lock on every traced line, which routes through that wrapper. When the traced frame belongs to a Cython extension, the frame walk has segfaulted in this specific matrix cell. The pure-Python leg never hits this combination.

## How

`tests/conftest.py` now reads `is_compiled()` from `dbus_fast._private.unmarshaller` at import time and the `blockbuster` autouse fixture yields `None` when the compiled extension is loaded, in addition to the existing s390x and benchmarks skips.

## Testing

Locally on macOS:

* `REQUIRE_CYTHON=1 poetry run python setup.py build_ext --inplace` followed by `poetry run pytest tests/test_fd_passing.py::test_fn_result_to_body` passes 19 cases including the previously-segfaulting `Signature: "a(hs)"` case.
* After deleting the `.so` files, the SKIP_CYTHON path passes the same tests with `blockbuster` active.
