### PR TITLE
fix(message_bus): skip socket shutdown when bus is already finalized

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -523,7 +523,7 @@ class BaseMessageBus:
         All pending  and future calls will error with a connection error.
         """
         self._user_disconnect = True
-        if self._sock:
+        if self._sock and not self._disconnected:
             try:
                 self._sock.shutdown(socket.SHUT_RDWR)
             except Exception:

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -78,7 +78,9 @@ async def test_unexpected_disconnect():
 
 
 @pytest.mark.asyncio
-async def test_disconnect_after_finalize_does_not_warn(caplog):
+async def test_disconnect_after_finalize_does_not_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """disconnect() on an already finalized bus does not warn about the socket."""
     bus = MessageBus()
     await bus.connect()

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -94,5 +94,6 @@ async def test_disconnect_after_finalize_does_not_warn(
 
     assert bus._user_disconnect
     assert not any(
-        "could not shut down socket" in record.message for record in caplog.records
+        "could not shut down socket" in record.getMessage()
+        for record in caplog.records
     )

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -94,6 +94,5 @@ async def test_disconnect_after_finalize_does_not_warn(
 
     assert bus._user_disconnect
     assert not any(
-        "could not shut down socket" in record.getMessage()
-        for record in caplog.records
+        "could not shut down socket" in record.getMessage() for record in caplog.records
     )

--- a/tests/test_disconnect.py
+++ b/tests/test_disconnect.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -74,3 +75,22 @@ async def test_unexpected_disconnect():
     bus.disconnect()
     with pytest.raises(OSError):
         await asyncio.wait_for(bus.wait_for_disconnect(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_after_finalize_does_not_warn(caplog):
+    """disconnect() on an already finalized bus does not warn about the socket."""
+    bus = MessageBus()
+    await bus.connect()
+    assert bus.connected
+
+    bus._finalize(EOFError())
+    assert bus._disconnected
+
+    with caplog.at_level(logging.WARNING, logger="dbus_fast.message_bus"):
+        bus.disconnect()
+
+    assert bus._user_disconnect
+    assert not any(
+        "could not shut down socket" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## What
Guard the socket shutdown in `BaseMessageBus.disconnect()` on `self._disconnected` so an already closed socket is not shut down a second time.

## Why
When the peer drops the connection first, `_finalize()` closes the socket but does not null `self._sock`; a later user driven `disconnect()` then calls `shutdown()` on the closed fd and logs `could not shut down socket` with `OSError [Errno 9] Bad file descriptor`. Harmless noise, but it has started showing up in Home Assistant logs on restart.

## Testing
Added `test_disconnect_after_finalize_does_not_warn`, which finalizes the bus and asserts the subsequent `disconnect()` does not emit the warning.
