### PR TITLE
fix(message_bus): log missing NO_REPLY_EXPECTED handler at debug

### DIFF
--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -844,12 +844,9 @@ class BaseMessageBus:
                         handler(msg, BLOCK_UNEXPECTED_REPLY)  # type: ignore[arg-type]
                     else:
                         # NO_REPLY_EXPECTED is fire-and-forget; the sender
-                        # explicitly opted out of a response, so a missing
-                        # handler is benign (and inherently racy when an
-                        # export is torn down while remote calls are in
-                        # flight, e.g. BlueZ AdvertisementMonitor1
-                        # DeviceFound after unexport but before
-                        # UnregisterMonitor completes).
+                        # opted out of a response, so a missing handler is
+                        # benign, and inherently racy when an export is
+                        # torn down while remote calls are in flight.
                         _LOGGER.debug(
                             '"%s.%s" with signature "%s" could not be found',
                             msg.interface,

--- a/src/dbus_fast/message_bus.py
+++ b/src/dbus_fast/message_bus.py
@@ -843,7 +843,14 @@ class BaseMessageBus:
                     if handler:
                         handler(msg, BLOCK_UNEXPECTED_REPLY)  # type: ignore[arg-type]
                     else:
-                        _LOGGER.error(
+                        # NO_REPLY_EXPECTED is fire-and-forget; the sender
+                        # explicitly opted out of a response, so a missing
+                        # handler is benign (and inherently racy when an
+                        # export is torn down while remote calls are in
+                        # flight, e.g. BlueZ AdvertisementMonitor1
+                        # DeviceFound after unexport but before
+                        # UnregisterMonitor completes).
+                        _LOGGER.debug(
                             '"%s.%s" with signature "%s" could not be found',
                             msg.interface,
                             msg.member,

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Annotated, no_type_check
 
 import pytest
@@ -258,6 +259,65 @@ async def test_methods(interface_class):
     assert reply.body == [
         'test.interface.does_not_exist with signature "" could not be found'
     ]
+
+    bus1.disconnect()
+    bus2.disconnect()
+    await asyncio.wait_for(bus1.wait_for_disconnect(), timeout=1)
+    await asyncio.wait_for(bus2.wait_for_disconnect(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_no_reply_expected_missing_handler_logs_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A NO_REPLY_EXPECTED call with no handler should log at DEBUG, not ERROR.
+
+    The remote end opted out of a reply, so a missing handler is benign
+    and inherently racy when an export is torn down while remote calls
+    are in flight (e.g. BlueZ AdvertisementMonitor1 DeviceFound after
+    unexport but before UnregisterMonitor completes).
+    """
+    bus1 = await MessageBus().connect()
+    bus2 = await MessageBus().connect()
+
+    interface = ExampleInterface("test.interface")
+    export_path = "/test/path"
+    bus1.export(export_path, interface)
+
+    fire_and_forget = Message(
+        destination=bus1.unique_name,
+        path=export_path,
+        interface=interface.name,
+        member="does_not_exist",
+        signature="",
+        body=[],
+        flags=MessageFlag.NO_REPLY_EXPECTED,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="dbus_fast.message_bus"):
+        await bus2.send(fire_and_forget)
+        # Round-trip a real call so the receiver has definitely processed
+        # the fire-and-forget message above before we inspect caplog.
+        reply = await bus2.call(
+            Message(
+                destination=bus1.unique_name,
+                path=export_path,
+                interface=interface.name,
+                member="ping",
+            )
+        )
+        assert reply is not None
+        assert reply.message_type == MessageType.METHOD_RETURN
+
+    matching = [
+        record
+        for record in caplog.records
+        if record.name == "dbus_fast.message_bus"
+        and "does_not_exist" in record.getMessage()
+        and "could not be found" in record.getMessage()
+    ]
+    assert len(matching) == 1, [r.getMessage() for r in caplog.records]
+    assert matching[0].levelno == logging.DEBUG
 
     bus1.disconnect()
     bus2.disconnect()

--- a/tests/service/test_methods.py
+++ b/tests/service/test_methods.py
@@ -270,13 +270,7 @@ async def test_methods(interface_class):
 async def test_no_reply_expected_missing_handler_logs_at_debug(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A NO_REPLY_EXPECTED call with no handler should log at DEBUG, not ERROR.
-
-    The remote end opted out of a reply, so a missing handler is benign
-    and inherently racy when an export is torn down while remote calls
-    are in flight (e.g. BlueZ AdvertisementMonitor1 DeviceFound after
-    unexport but before UnregisterMonitor completes).
-    """
+    """A NO_REPLY_EXPECTED call with no handler should log at DEBUG, not ERROR."""
     bus1 = await MessageBus().connect()
     bus2 = await MessageBus().connect()
 


### PR DESCRIPTION
## Summary

A method call flagged NO_REPLY_EXPECTED with no matching handler is currently logged at ERROR; the remote opted out of a reply, so a missing handler is benign and unactionable from the receiver side. The expects-reply branch right below already returns UNKNOWN_METHOD to the caller without logging, so this aligns the two paths.

This trips on Home Assistant 2026.6.0b0 (issue home-assistant/core#172376) when habluetooth flips a bleak BlueZ scanner between passive and active for an AUTO active window; bleak unexports its AdvertisementMonitor path before BlueZ finishes processing UnregisterMonitor, so DeviceFound calls already in flight land on a path that no longer has a handler.

## Test plan

- New test `test_no_reply_expected_missing_handler_logs_at_debug` sends a NO_REPLY_EXPECTED call to a non-existent method and asserts the dbus_fast.message_bus record is at DEBUG, not ERROR
- Existing tests in `tests/service/test_methods.py` still pass; the expects-reply branch is unchanged and still returns the `... could not be found` body via UNKNOWN_METHOD