### PR TITLE
fix: gate cython import behind TYPE_CHECKING to avoid bundler bloat

### DIFF
--- a/src/dbus_fast/_private/unmarshaller.py
+++ b/src/dbus_fast/_private/unmarshaller.py
@@ -245,10 +245,16 @@ def build_simple_parsers(
     return parsers
 
 
-try:
+# `import cython` is gated behind TYPE_CHECKING so static bundlers
+# (PyInstaller, Nuitka) don't follow it and drag the Cython package
+# (and its numpy bindings) into frozen apps. Cython still recognises
+# the import at compile time and keeps `cython.compiled` magic; the
+# else branch is what actually runs uncompiled.
+if TYPE_CHECKING:
     import cython
-except ImportError:
+else:
     from ._cython_compat import FAKE_CYTHON as cython
+
 int_ = int
 bytearray_ = bytearray
 


### PR DESCRIPTION
Fixes #729.

dbus-fast has no third-party runtime dependencies, but `unmarshaller.py` does `import cython` so Cython's pure-python mode can keep the `cython.compiled` magic. PyInstaller and Nuitka follow that import statically, pull in the whole Cython package, and Cython ships numpy bindings, so frozen apps end up bundling Cython and numpy for no runtime reason. That is the bloat reported in #729; dbus-next never triggers it because it has no `import cython`.

Gating the import behind `TYPE_CHECKING` keeps it invisible to the bundlers (they skip `TYPE_CHECKING` blocks) while Cython still recognises it at compile time, so the compiled wheel is unchanged.

Verified all four paths:

* compiled wheel (`REQUIRE_CYTHON=1`): `cython.compiled` is still `True`, fast branches stay alive
* pure python with cython installed: `False`
* pure python without cython installed: `False`, no crash
* bundlers no longer follow the import, so Cython/numpy are not pulled in

Marshaller tests pass in both compiled and pure-python builds.
