### PR TITLE
ci: scope release environment, OIDC, and write perms to main-only job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,15 +176,47 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: dbus-run-session -- poetry run pytest --no-cov -vvvvv --codspeed tests/benchmarks
 
+  # PRs and non-main pushes: validate the PSR config with a read-only dry run.
+  # No environment and no elevated permissions, so PR runs can never enter the
+  # release environment (avoiding approval-gate hangs) or hold OIDC/write tokens.
+  release_dry_run:
+    needs:
+      - test
+      - lint
+    if: github.ref_name != 'main'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Create local branch name
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+        run: git switch -C "$BRANCH"
+
+      - name: Test release
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
+        with:
+          no_operation_mode: true
+
+  # main only: real release + publish. The environment and OIDC/write
+  # permissions live here so they are never granted on PR runs.
   release:
     needs:
       - test
       - lint
+    if: github.ref_name == 'main'
 
     runs-on: ubuntu-latest
     environment: release
     concurrency:
-      group: release-${{ github.head_ref || github.ref }}
+      group: release-${{ github.ref }}
       cancel-in-progress: false
     permissions:
       id-token: write
@@ -201,21 +233,12 @@ jobs:
 
       - name: Create local branch name
         env:
-          BRANCH: ${{ github.head_ref || github.ref_name }}
+          BRANCH: ${{ github.ref_name }}
         run: git switch -C "$BRANCH"
 
-      # Do a dry run of PSR
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
-        if: github.ref_name != 'main'
-        with:
-          no_operation_mode: true
-
-      # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
         uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0 # v10.5.3
         id: release
-        if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The `release` job ran on every trigger including `pull_request` while holding `id-token: write` plus `contents: write` and entering the `release` environment, even though only its steps were branch gated. PR runs check out the untrusted PR ref under those permissions, pend on environment approval, and expose OIDC for no benefit since publishing is already gated to main.

This splits it into a permission-less `release_dry_run` job (`contents: read`, no environment, no OIDC) for PRs and non-main pushes, and a main-only `release` job that alone holds the environment, write, and OIDC. The PR dry-run signal is unchanged.

Fixes #769.
